### PR TITLE
Add support for linters, as well as matrix support for rspec

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,31 @@
+name: Linters
+
+on: [push]
+
+jobs:
+  StandardRB:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+
+      - name: Cache gems
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-linters-${{ hashFiles('Gemfile.lock') }}
+          restore-keys:
+            ${{ runner.os }}-linters-
+
+      - name: Install gems
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Run standard
+        run: bundle exec standardrb
+
+      - name: Run rubocop (complexity checks)
+        run: bundle exec rubocop --parallel

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,33 @@
+name: RSpec
+
+on: [push]
+
+jobs:
+  RSpec:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', 'head']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Cache gems
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-rspec-${{ matrix.ruby-version }}-${{ hashFiles('Gemfile.lock') }}
+          restore-keys:
+            ${{ runner.os }}-rspec-${{ matrix.ruby-version }}-
+
+      - name: Install gems
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Run RSpec
+        run: bundle exec rspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,21 @@
+---
+AllCops:
+  SuggestExtensions: false
+  DisabledByDefault: true
+
+Metrics/AbcSize:
+  Max: 15
+Metrics/CyclomaticComplexity:
+  Max: 8
+Metrics/PerceivedComplexity:
+  Max: 7
+
+Metrics/ClassLength:
+  CountComments: false
+  Max: 150
+Metrics/MethodLength:
+  CountComments: false
+  Max: 15
+Metrics/ParameterLists:
+  Max: 5
+  CountKeywordArgs: true

--- a/quiet_quality.gemspec
+++ b/quiet_quality.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "https://github.com/nevinera/quiet_quality"
   spec.license = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Add support for the following Github workflows:

- `rspec` run against a matrix of the tip of each supported ruby version (2.6+)
- `standardrb` check
- `rubocop` check

Resolves https://github.com/nevinera/quiet_quality/issues/5