### PR TITLE
Nev 4  support standardrb

### DIFF
--- a/lib/quiet_quality/message.rb
+++ b/lib/quiet_quality/message.rb
@@ -1,6 +1,7 @@
 module QuietQuality
   class Message
-    attr_reader :path, :body, :start_line, :stop_line, :annotated_line, :level, :rule
+    attr_writer :annotated_line
+    attr_reader :path, :body, :start_line, :stop_line, :level, :rule
 
     def self.load(hash)
       new(**hash)
@@ -12,9 +13,13 @@ module QuietQuality
       @body = @attrs.fetch("body")
       @start_line = @attrs.fetch("start_line")
       @stop_line = @attrs.fetch("stop_line", @start_line)
-      @annotated_line = @attrs.fetch("annotated_line", @stop_line)
+      @annotated_line = @attrs.fetch("annotated_line", nil)
       @level = @attrs.fetch("level", nil)
       @rule = @attrs.fetch("rule", nil)
+    end
+
+    def annotated_line
+      @annotated_line || @stop_line || @start_line
     end
 
     def to_h

--- a/lib/quiet_quality/messages.rb
+++ b/lib/quiet_quality/messages.rb
@@ -35,6 +35,10 @@ module QuietQuality
       messages
     end
 
+    def empty?
+      messages.length == 0
+    end
+
     def each(&block)
       if block
         messages.each(&block)

--- a/lib/quiet_quality/tools.rb
+++ b/lib/quiet_quality/tools.rb
@@ -1,0 +1,8 @@
+module QuietQuality
+  module Tools
+    Error = Class.new(::QuietQuality::Error)
+  end
+end
+
+glob = File.expand_path("../tools/*.rb", __FILE__)
+Dir.glob(glob).sort.each { |f| require f }

--- a/lib/quiet_quality/tools.rb
+++ b/lib/quiet_quality/tools.rb
@@ -8,3 +8,12 @@ end
 
 glob = File.expand_path("../tools/*.rb", __FILE__)
 Dir.glob(glob).sort.each { |f| require f }
+
+# reopen the class after the tools have been loaded, so we can list them for reference elsewhere.
+module QuietQuality
+  module Tools
+    AVAILABLE = {
+      standardrb: Standardrb
+    }
+  end
+end

--- a/lib/quiet_quality/tools.rb
+++ b/lib/quiet_quality/tools.rb
@@ -1,3 +1,5 @@
+require "open3"
+
 module QuietQuality
   module Tools
     Error = Class.new(::QuietQuality::Error)

--- a/lib/quiet_quality/tools/standardrb.rb
+++ b/lib/quiet_quality/tools/standardrb.rb
@@ -1,0 +1,10 @@
+module QuietQuality
+  module Tools
+    module Standardrb
+      ExecutionError = Class.new(::QuietQuality::Error)
+    end
+  end
+end
+
+glob = File.expand_path("../standardrb/*.rb", __FILE__)
+Dir.glob(glob).sort.each { |f| require f }

--- a/lib/quiet_quality/tools/standardrb.rb
+++ b/lib/quiet_quality/tools/standardrb.rb
@@ -1,7 +1,8 @@
 module QuietQuality
   module Tools
     module Standardrb
-      ExecutionError = Class.new(::QuietQuality::Error)
+      ExecutionError = Class.new(Tools::Error)
+      ParsingError = Class.new(Tools::Error)
     end
   end
 end

--- a/lib/quiet_quality/tools/standardrb/parser.rb
+++ b/lib/quiet_quality/tools/standardrb/parser.rb
@@ -1,0 +1,46 @@
+module QuietQuality
+  module Tools
+    module Standardrb
+      class Parser
+        def initialize(text)
+          @text = text
+        end
+
+        def messages
+          return @_messages if defined?(@_messages)
+          messages = content
+            .fetch(:files)
+            .map { |f| messages_for_file(f) }
+            .flatten
+          @_messages = Messages.new(messages)
+        end
+
+        private
+
+        attr_reader :text
+
+        def content
+          @_content ||= JSON.parse(text, symbolize_names: true)
+        end
+
+        def messages_for_file(file_details)
+          path = file_details.fetch(:path)
+          file_details.fetch(:offenses).map do |offense|
+            message_for_offense(path, offense)
+          end
+        end
+
+        def message_for_offense(path, offense)
+          Message.new(
+            path: path,
+            body: offense.fetch(:message),
+            start_line: offense.dig(:location, :start_line),
+            stop_line: offense.dig(:location, :last_line),
+            level: offense.fetch(:severity, nil),
+            rule: offense.fetch(:cop_name, nil)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/quiet_quality/tools/standardrb/runner.rb
+++ b/lib/quiet_quality/tools/standardrb/runner.rb
@@ -1,0 +1,54 @@
+module QuietQuality
+  module Tools
+    module Standardrb
+      class Runner
+        MAX_FILES = 100
+        NO_FILES_OUTPUT = '{"files": [], "summary": {"offense_count": 0}}'
+
+        # Supplying changed_files: nil means "run against all files".
+        # error_stream is really just injectable for unit-testing purposes.
+        def initialize(changed_files: nil, error_stream: $stderr)
+          @changed_files = changed_files
+          @error_stream = error_stream
+        end
+
+        def invoke!
+          return NO_FILES_OUTPUT if skip_execution?
+          out, err, stat = Open3.capture3(*command)
+          error_stream.write(err)
+          fail(ExecutionError, "Execution of standardrb failed with #{stat.exitstatus}") unless stat.success?
+          out
+        end
+
+        private
+
+        attr_reader :changed_files, :error_stream
+
+        # If we were told that _no files changed_ (which is distinct from not being told that
+        # any files changed - a [] instead of a nil), then we shouldn't run rubocop at all.
+        def skip_execution?
+          changed_files && relevant_files.empty?
+        end
+
+        # Note: if target_files goes over MAX_FILES, it's _empty_ instead - that means that
+        # we run against the full repository instead of the specific files (rubocop's behavior
+        # when no target files are specified)
+        def command
+          return nil if skip_execution?
+          ["rubocop", "-f", "json", "--fail-level", "fatal"] + target_files.sort
+        end
+
+        def relevant_files
+          return nil if changed_files.nil?
+          changed_files.select { |path| path.end_with?(".rb") }
+        end
+
+        def target_files
+          return [] if changed_files.nil?
+          return [] if relevant_files.length > MAX_FILES
+          relevant_files
+        end
+      end
+    end
+  end
+end

--- a/lib/quiet_quality/tools/standardrb/runner.rb
+++ b/lib/quiet_quality/tools/standardrb/runner.rb
@@ -35,7 +35,7 @@ module QuietQuality
         # when no target files are specified)
         def command
           return nil if skip_execution?
-          ["rubocop", "-f", "json", "--fail-level", "fatal"] + target_files.sort
+          ["standardrb", "-f", "json", "--fail-level", "fatal"] + target_files.sort
         end
 
         def relevant_files

--- a/spec/fixtures/tools/standardrb/failures.json
+++ b/spec/fixtures/tools/standardrb/failures.json
@@ -55,7 +55,7 @@
           "location": {
             "start_line": 9,
             "start_column": 9,
-            "last_line": 9,
+            "last_line": 10,
             "last_column": 25,
             "length": 17,
             "line": 9,

--- a/spec/fixtures/tools/standardrb/failures.json
+++ b/spec/fixtures/tools/standardrb/failures.json
@@ -1,0 +1,226 @@
+{
+  "metadata": {
+    "rubocop_version": "1.50.2",
+    "ruby_engine": "ruby",
+    "ruby_version": "2.7.6",
+    "ruby_patchlevel": "219",
+    "ruby_platform": "x86_64-darwin22"
+  },
+  "files": [
+    {
+      "path": "Gemfile",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/message.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/messages.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools/standardrb.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools/standardrb/parser.rb",
+      "offenses": [
+        {
+          "severity": "convention",
+          "message": "Style/EmptyMethod: Put the `end` of empty method definitions on the next line.",
+          "cop_name": "Style/EmptyMethod",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 9,
+            "start_column": 9,
+            "last_line": 9,
+            "last_column": 25,
+            "length": 17,
+            "line": 9,
+            "column": 9
+          }
+        },
+        {
+          "severity": "convention",
+          "message": "Style/SingleLineMethods: Avoid single-line method definitions.",
+          "cop_name": "Style/SingleLineMethods",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 9,
+            "start_column": 9,
+            "last_line": 9,
+            "last_column": 25,
+            "length": 17,
+            "line": 9,
+            "column": 9
+          }
+        },
+        {
+          "severity": "convention",
+          "message": "Layout/EmptyLinesAroundMethodBody: Extra empty line detected at method body beginning.",
+          "cop_name": "Layout/EmptyLinesAroundMethodBody",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 20,
+            "start_column": 1,
+            "last_line": 21,
+            "last_column": 1,
+            "length": 1,
+            "line": 20,
+            "column": 1
+          }
+        },
+        {
+          "severity": "convention",
+          "message": "Layout/EmptyLines: Extra blank line detected.",
+          "cop_name": "Layout/EmptyLines",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 21,
+            "start_column": 1,
+            "last_line": 22,
+            "last_column": 1,
+            "length": 1,
+            "line": 21,
+            "column": 1
+          }
+        },
+        {
+          "severity": "convention",
+          "message": "Layout/EmptyLines: Extra blank line detected.",
+          "cop_name": "Layout/EmptyLines",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 22,
+            "start_column": 1,
+            "last_line": 23,
+            "last_column": 1,
+            "length": 1,
+            "line": 22,
+            "column": 1
+          }
+        },
+        {
+          "severity": "convention",
+          "message": "Layout/EmptyLinesAroundMethodBody: Extra empty line detected at method body end.",
+          "cop_name": "Layout/EmptyLinesAroundMethodBody",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 22,
+            "start_column": 1,
+            "last_line": 23,
+            "last_column": 1,
+            "length": 1,
+            "line": 22,
+            "column": 1
+          }
+        }
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools/standardrb/runner.rb",
+      "offenses": [
+        {
+          "severity": "convention",
+          "message": "Layout/ExtraSpacing: Unnecessary spacing detected.",
+          "cop_name": "Layout/ExtraSpacing",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 19,
+            "start_column": 16,
+            "last_line": 19,
+            "last_column": 16,
+            "length": 1,
+            "line": 19,
+            "column": 16
+          }
+        },
+        {
+          "severity": "convention",
+          "message": "Layout/SpaceInsideParens: Space inside parentheses detected.",
+          "cop_name": "Layout/SpaceInsideParens",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 19,
+            "start_column": 16,
+            "last_line": 19,
+            "last_column": 17,
+            "length": 2,
+            "line": 19,
+            "column": 16
+          }
+        }
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/version.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "quiet_quality.gemspec",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/quiet_quality/message_spec.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/quiet_quality/messages_spec.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/spec_helper.rb",
+      "offenses": [
+
+      ]
+    }
+  ],
+  "summary": {
+    "offense_count": 8,
+    "target_file_count": 14,
+    "inspected_file_count": 14
+  }
+}

--- a/spec/fixtures/tools/standardrb/no-failures.json
+++ b/spec/fixtures/tools/standardrb/no-failures.json
@@ -1,0 +1,100 @@
+{
+  "metadata": {
+    "rubocop_version": "1.50.2",
+    "ruby_engine": "ruby",
+    "ruby_version": "2.7.6",
+    "ruby_patchlevel": "219",
+    "ruby_platform": "x86_64-darwin22"
+  },
+  "files": [
+    {
+      "path": "Gemfile",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/message.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/messages.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools/standardrb.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools/standardrb/parser.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools/standardrb/runner.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/version.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "quiet_quality.gemspec",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/quiet_quality/message_spec.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/quiet_quality/messages_spec.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/spec_helper.rb",
+      "offenses": [
+
+      ]
+    }
+  ],
+  "summary": {
+    "offense_count": 0,
+    "target_file_count": 14,
+    "inspected_file_count": 14
+  }
+}

--- a/spec/quiet_quality/message_spec.rb
+++ b/spec/quiet_quality/message_spec.rb
@@ -65,9 +65,37 @@ RSpec.describe QuietQuality::Message do
   include_examples "required field", :body, :body
   include_examples "required field", :start_line, :start_line
   include_examples "field with default", :stop_line, default_binding: :start_line
-  include_examples "field with default", :annotated_line, default_binding: :stop_line
   include_examples "field with default", :level, default_value: nil
   include_examples "field with default", :rule, default_value: nil
+
+  describe "#annotated_line" do
+    subject { message.annotated_line }
+
+    context "when it is set during initialization" do
+      let(:annotated_line) { 19 }
+      it { is_expected.to eq(19) }
+    end
+
+    context "when it is set later" do
+      let(:annotated_line) { nil }
+      before { message.annotated_line = 44 }
+      it { is_expected.to eq(44) }
+    end
+
+    context "when it is not set" do
+      let(:annotated_line) { nil }
+
+      context "but stop_line is" do
+        let(:stop_line) { 28 }
+        it { is_expected.to eq(28) }
+      end
+
+      context "and neither is stop_line" do
+        let(:stop_line) { nil }
+        it { is_expected.to eq(start_line) }
+      end
+    end
+  end
 
   describe "#to_h" do
     subject(:to_h) { message.to_h }

--- a/spec/quiet_quality/messages_spec.rb
+++ b/spec/quiet_quality/messages_spec.rb
@@ -3,7 +3,8 @@ RSpec.describe QuietQuality::Messages do
   let(:m2_data) { {path: "/foo/2", body: "body2", start_line: 2, stop_line: 5} }
   let(:m1) { QuietQuality::Message.new(**m1_data) }
   let(:m2) { QuietQuality::Message.new(**m2_data) }
-  subject(:messages) { described_class.new([m1, m2]) }
+  let(:supplied_messages) { [m1, m2] }
+  subject(:messages) { described_class.new(supplied_messages) }
 
   describe ".load_data" do
     let(:data) { [m1_data, m2_data] }
@@ -131,6 +132,20 @@ RSpec.describe QuietQuality::Messages do
     subject(:all) { messages.all }
     it { is_expected.to be_an(Array) }
     it { is_expected.to contain_exactly(m1, m2) }
+  end
+
+  describe "#empty?" do
+    subject(:empty?) { messages.empty? }
+
+    context "when there are no messages" do
+      let(:supplied_messages) { [] }
+      it { is_expected.to be_truthy }
+    end
+
+    context "when there are some messages" do
+      before { expect(supplied_messages).not_to be_empty }
+      it { is_expected.to be_falsey }
+    end
   end
 
   describe "Enumerable" do

--- a/spec/quiet_quality/tools/standardrb/parser_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/parser_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe QuietQuality::Tools::Standardrb::Parser do
+  subject(:parser) { described_class.new(text) }
+
+  describe "#messages" do
+    let(:text) { fixture_content("tools", "standardrb", "no-failures.json") }
+    subject(:messages) { parser.messages }
+
+    it "is memoized" do
+      first_messages = parser.messages
+      expect(parser.messages.object_id).to eq(first_messages.object_id)
+    end
+
+    context "when there are no offenses" do
+      let(:text) { fixture_content("tools", "standardrb", "no-failures.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+    end
+
+    context "when there are some offenses" do
+      let(:text) { fixture_content("tools", "standardrb", "failures.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+      it { is_expected.not_to be_empty }
+
+      it "has the expected offenses in it" do
+        expect(messages.count).to eq(8)
+        expect(messages.map(&:start_line)).to contain_exactly(9, 9, 20, 21, 22, 22, 19, 19)
+      end
+
+      it "fully populates the messages" do
+        expect(messages.first.path).to eq("lib/quiet_quality/tools/standardrb/parser.rb")
+        expect(messages.first.body).to match(/of empty method definitions on the next line/)
+        expect(messages.first.start_line).to eq(9)
+        expect(messages.first.stop_line).to eq(10)
+        expect(messages.first.stop_line).to eq(10)
+        expect(messages.first.level).to eq("convention")
+        expect(messages.first.rule).to eq("Style/EmptyMethod")
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/tools/standardrb/runner_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/runner_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
   describe "#invoke!" do
     subject(:invoke!) { runner.invoke! }
 
-    context "when the rubocop command _fails_" do
+    context "when the standardrb command _fails_" do
       let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
 
       it "raises a Standardrb::ExecutionError" do
@@ -23,11 +23,11 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
       let(:changed_files) { nil }
       it { is_expected.to eq("fake output") }
 
-      it "calls rubocop correctly, with no targets" do
+      it "calls standardrb correctly, with no targets" do
         invoke!
         expect(Open3)
           .to have_received(:capture3)
-          .with("rubocop", "-f", "json", "--fail-level", "fatal")
+          .with("standardrb", "-f", "json", "--fail-level", "fatal")
       end
     end
 
@@ -35,7 +35,7 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
       let(:changed_files) { [] }
       it { is_expected.to eq(described_class::NO_FILES_OUTPUT) }
 
-      it "does not call rubocop" do
+      it "does not call standardrb" do
         invoke!
         expect(Open3).not_to have_received(:capture3)
       end
@@ -51,7 +51,7 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
         let(:file2) { "bar.js" }
         let(:file3) { "baz.ts" }
 
-        it "does not call rubocop" do
+        it "does not call standardrb" do
           invoke!
           expect(Open3).not_to have_received(:capture3)
         end
@@ -60,11 +60,11 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
       context "and contains some ruby files" do
         it { is_expected.to eq("fake output") }
 
-        it "calls rubocop correctly, with changed and relevant targets" do
+        it "calls standardrb correctly, with changed and relevant targets" do
           invoke!
           expect(Open3)
             .to have_received(:capture3)
-            .with("rubocop", "-f", "json", "--fail-level", "fatal", "bar.rb", "baz.rb")
+            .with("standardrb", "-f", "json", "--fail-level", "fatal", "bar.rb", "baz.rb")
         end
       end
 
@@ -72,11 +72,11 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
         before { stub_const("QuietQuality::Tools::Standardrb::Runner::MAX_FILES", 1) }
         it { is_expected.to eq("fake output") }
 
-        it "calls rubocop correctly, with no targets" do
+        it "calls standardrb correctly, with no targets" do
           invoke!
           expect(Open3)
             .to have_received(:capture3)
-            .with("rubocop", "-f", "json", "--fail-level", "fatal")
+            .with("standardrb", "-f", "json", "--fail-level", "fatal")
         end
       end
     end

--- a/spec/quiet_quality/tools/standardrb/runner_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/runner_spec.rb
@@ -1,0 +1,84 @@
+RSpec.describe QuietQuality::Tools::Standardrb::Runner do
+  let(:changed_files) { nil }
+  let(:error_stream) { instance_double(IO, write: nil) }
+  subject(:runner) { described_class.new(changed_files: changed_files, error_stream: error_stream) }
+
+  let(:out) { "fake output" }
+  let(:err) { "fake error" }
+  let(:stat) { instance_double(Process::Status, success?: true, exitstatus: 0) }
+  before { allow(Open3).to receive(:capture3).and_return([out, err, stat]) }
+
+  describe "#invoke!" do
+    subject(:invoke!) { runner.invoke! }
+
+    context "when the rubocop command _fails_" do
+      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
+
+      it "raises a Standardrb::ExecutionError" do
+        expect { invoke! }.to raise_error(QuietQuality::Tools::Standardrb::ExecutionError)
+      end
+    end
+
+    context "when changed_files is nil" do
+      let(:changed_files) { nil }
+      it { is_expected.to eq("fake output") }
+
+      it "calls rubocop correctly, with no targets" do
+        invoke!
+        expect(Open3)
+          .to have_received(:capture3)
+          .with("rubocop", "-f", "json", "--fail-level", "fatal")
+      end
+    end
+
+    context "when changed_files is empty" do
+      let(:changed_files) { [] }
+      it { is_expected.to eq(described_class::NO_FILES_OUTPUT) }
+
+      it "does not call rubocop" do
+        invoke!
+        expect(Open3).not_to have_received(:capture3)
+      end
+    end
+
+    context "when changed_files is full" do
+      let(:file1) { "foo.js" }
+      let(:file2) { "bar.rb" }
+      let(:file3) { "baz.rb" }
+      let(:changed_files) { [file1, file2, file3] }
+
+      context "but contains no ruby files" do
+        let(:file2) { "bar.js" }
+        let(:file3) { "baz.ts" }
+
+        it "does not call rubocop" do
+          invoke!
+          expect(Open3).not_to have_received(:capture3)
+        end
+      end
+
+      context "and contains some ruby files" do
+        it { is_expected.to eq("fake output") }
+
+        it "calls rubocop correctly, with changed and relevant targets" do
+          invoke!
+          expect(Open3)
+            .to have_received(:capture3)
+            .with("rubocop", "-f", "json", "--fail-level", "fatal", "bar.rb", "baz.rb")
+        end
+      end
+
+      context "and contains too many ruby files" do
+        before { stub_const("QuietQuality::Tools::Standardrb::Runner::MAX_FILES", 1) }
+        it { is_expected.to eq("fake output") }
+
+        it "calls rubocop correctly, with no targets" do
+          invoke!
+          expect(Open3)
+            .to have_received(:capture3)
+            .with("rubocop", "-f", "json", "--fail-level", "fatal")
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,21 @@ require "pry"
 
 require File.expand_path("../../lib/quiet_quality", __FILE__)
 
+gem_root = File.expand_path("../..", __FILE__)
+FIXTURES_DIRECTORY = File.join(gem_root, "spec", "fixtures")
+
+def fixture_path(*parts)
+  File.join(FIXTURES_DIRECTORY, *parts)
+end
+
+def fixture_content(*parts)
+  File.read(fixture_path(*parts))
+end
+
+def fixture_json(*parts)
+  JSON.parse(fixture_content(*parts))
+end
+
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   config.mock_with :rspec


### PR DESCRIPTION
Resolves #4 

* Add the namespace modules for `QuietQuality::Tools` and `QuietQuality::Tools::Standardrb`
* Update Message objects to let `annotated_line` be writable - normally it will be set after the fact, and not as part of parsing.
* Implement `QuietQuality::Messages#empty?` for some testing conveniences (there are some methods I would have thought Enumerable would give us, but didn't)
* Add some basic fixture helpers, and generate a couple of fixtures by running standardrb against `quiet_quality` with and without some introduced issues.
* Add the `QuietQuality::Tools::Standardrb::Runner`
* Add the `QuietQuality::Tools::Standardrb::Parser`