### PR TITLE
Add a FileChanges abstraction

### DIFF
--- a/lib/quiet_quality.rb
+++ b/lib/quiet_quality.rb
@@ -1,6 +1,7 @@
 require "git"
 require "json"
 require "yaml"
+require "set"
 
 module QuietQuality
   Error = Class.new(StandardError)

--- a/lib/quiet_quality.rb
+++ b/lib/quiet_quality.rb
@@ -1,7 +1,10 @@
 require "git"
 require "json"
 require "yaml"
-require "set"
+
+# 'set' doesn't need requiring after ruby 3.2, but it won't hurt anything.
+# And we're compatible back to 2.6
+require "set" # rubocop:disable Lint/RedundantRequireStatement
 
 module QuietQuality
   Error = Class.new(StandardError)

--- a/lib/quiet_quality/changed_file.rb
+++ b/lib/quiet_quality/changed_file.rb
@@ -1,0 +1,14 @@
+module QuietQuality
+  class ChangedFile
+    attr_reader :path
+
+    def initialize(path:, lines:)
+      @path = path
+      @lines = lines
+    end
+
+    def lines
+      @_lines ||= @lines.to_set
+    end
+  end
+end

--- a/lib/quiet_quality/changed_files.rb
+++ b/lib/quiet_quality/changed_files.rb
@@ -1,0 +1,23 @@
+module QuietQuality
+  class ChangedFiles
+    attr_reader :files
+
+    def initialize(files)
+      @files = files
+    end
+
+    def file(path)
+      files_by_path.fetch(path, nil)
+    end
+
+    def include?(path)
+      files_by_path.include?(path)
+    end
+
+    private
+
+    def files_by_path
+      @_files_by_path ||= files.map { |f| [f.path, f] }.to_h
+    end
+  end
+end

--- a/spec/quiet_quality/changed_file_spec.rb
+++ b/spec/quiet_quality/changed_file_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe QuietQuality::ChangedFile do
+  let(:path) { "foo/bar.rb" }
+  let(:lines) { [1, 3, 5, 9, 10] }
+  subject(:changed_file) { described_class.new(path: path, lines: lines) }
+
+  describe "#path" do
+    subject { changed_file.path }
+    it { is_expected.to be_a(String) }
+    it { is_expected.to eq(path) }
+  end
+
+  describe "#lines" do
+    subject { changed_file.lines }
+    it { is_expected.to be_a(Set) }
+    it { is_expected.to contain_exactly(1, 3, 5, 9, 10) }
+  end
+end

--- a/spec/quiet_quality/changed_files_spec.rb
+++ b/spec/quiet_quality/changed_files_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe QuietQuality::ChangedFiles do
+  let(:foo_file) { QuietQuality::ChangedFile.new(path: "path/foo.rb", lines: [1, 2, 3, 5, 10]) }
+  let(:bar_file) { QuietQuality::ChangedFile.new(path: "path/bar.rb", lines: [5, 6, 7, 14, 15]) }
+  let(:files) { [foo_file, bar_file] }
+  subject(:changed_files) { described_class.new(files) }
+
+  describe "#files" do
+    subject { changed_files.files }
+    it { is_expected.to contain_exactly(foo_file, bar_file) }
+  end
+
+  describe "#file" do
+    subject { changed_files.file(path) }
+
+    context "for a path that matches one of the files" do
+      let(:path) { bar_file.path }
+      it { is_expected.to eq(bar_file) }
+    end
+
+    context "for a path that doesn't match any file" do
+      let(:path) { "path/baz.js" }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#include?" do
+    subject { changed_files.include?(path) }
+
+    context "for a path that matches one of the files" do
+      let(:path) { foo_file.path }
+      it { is_expected.to be_truthy }
+    end
+
+    context "for a path that doesn't match any file" do
+      let(:path) { "path/baz.js" }
+      it { is_expected.to be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
The git-diff output needs to produce something that the annotation-line-finder can consume. So we don't need to block the latter on the former, here's an abstraction they can share, which we can grow more access methods onto later.

Roughly speaking, `ChangedFile` represents a single file's changes, and `ChangedFiles` represents a set of changed files. In anticipation of the actual needs, ChangedFiles can tell us if a given file has any changes, and ChangedFile exposes a Set of lines. I suspect we'll want a more special-purpose comparison data structure later for comparing Message line-ranges to ChangedFile objects to set the Message's annotation_line, but that can be implemented separately and later.