### PR TITLE
Add an AnnotationLocator class

### DIFF
--- a/lib/quiet_quality/annotation_locator.rb
+++ b/lib/quiet_quality/annotation_locator.rb
@@ -9,6 +9,10 @@ module QuietQuality
       message.annotated_line = changed_file ? file_line_for(message, changed_file) : nil
     end
 
+    def update_all!(messages)
+      messages.map { |m| update!(m) }.compact.length
+    end
+
     private
 
     attr_reader :changed_files

--- a/lib/quiet_quality/annotation_locator.rb
+++ b/lib/quiet_quality/annotation_locator.rb
@@ -1,0 +1,28 @@
+module QuietQuality
+  class AnnotationLocator
+    def initialize(changed_files:)
+      @changed_files = changed_files
+    end
+
+    def update!(message)
+      changed_file = changed_files.file(message.path)
+      message.annotated_line = changed_file ? file_line_for(message, changed_file) : nil
+    end
+
+    private
+
+    attr_reader :changed_files
+
+    def file_line_for(message, changed_file)
+      message_range = (message.start_line..message.stop_line)
+      last_match(changed_file.line_numbers, message_range)
+    end
+
+    def last_match(array, range)
+      array.reverse_each do |value|
+        return value if range.cover?(value)
+      end
+      nil
+    end
+  end
+end

--- a/lib/quiet_quality/changed_file.rb
+++ b/lib/quiet_quality/changed_file.rb
@@ -10,5 +10,9 @@ module QuietQuality
     def lines
       @_lines ||= @lines.to_set
     end
+
+    def line_numbers
+      @_line_numbers ||= @lines.sort
+    end
   end
 end

--- a/lib/quiet_quality/message.rb
+++ b/lib/quiet_quality/message.rb
@@ -1,6 +1,6 @@
 module QuietQuality
   class Message
-    attr_writer :annotated_line
+    attr_accessor :annotated_line
     attr_reader :path, :body, :start_line, :stop_line, :level, :rule
 
     def self.load(hash)
@@ -16,10 +16,6 @@ module QuietQuality
       @annotated_line = @attrs.fetch("annotated_line", nil)
       @level = @attrs.fetch("level", nil)
       @rule = @attrs.fetch("rule", nil)
-    end
-
-    def annotated_line
-      @annotated_line || @stop_line || @start_line
     end
 
     def to_h

--- a/spec/quiet_quality/annotation_locator_spec.rb
+++ b/spec/quiet_quality/annotation_locator_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe QuietQuality::AnnotationLocator do
+  let(:foo_file) { QuietQuality::ChangedFile.new(path: "path/foo.rb", lines: [1, 2, 3, 5, 10]) }
+  let(:bar_file) { QuietQuality::ChangedFile.new(path: "path/bar.rb", lines: [5, 6, 7, 14, 15]) }
+  let(:changed_files) { QuietQuality::ChangedFiles.new([foo_file, bar_file]) }
+  subject(:locator) { described_class.new(changed_files: changed_files) }
+
+  def build_message(path, body, start, stop=nil)
+    QuietQuality::Message.new(path: path, body: body, start_line: start, stop_line: stop)
+  end
+
+  describe "#update!" do
+    subject(:update!) { locator.update!(message) }
+
+    context "for a message that doesn't match a changed file" do
+      let(:message) { build_message("path/baz.rb", "yes!", 1, 50) }
+      it { is_expected.to be_nil }
+
+      it "doesn't update annotated_line from nil" do
+        expect { update! }.not_to change { message.annotated_line }.from(nil)
+      end
+    end
+
+    context "for a message that doesn't match a changed line" do
+      let(:message) { build_message(foo_file.path, "yes!", 6, 8) }
+      it { is_expected.to be_nil }
+
+      it "doesn't update annotated_line from nil" do
+        expect { update! }.not_to change { message.annotated_line }.from(nil)
+      end
+    end
+
+    context "for a message that matches a single changed line" do
+      let(:message) { build_message(foo_file.path, "yes!", 5, 5) }
+      it { is_expected.to eq(5) }
+
+      it "updates annotated_line to match" do
+        expect { update! }.to change { message.annotated_line }.from(nil).to(5)
+      end
+    end
+
+    context "for a message that matches several changed lines" do
+      let(:message) { build_message(foo_file.path, "yes!", 1, 3) }
+      it { is_expected.to eq(3) }
+
+      it "updates annotated_line to match" do
+        expect { update! }.to change { message.annotated_line }.from(nil).to(3)
+      end
+
+      context "including more lines than were changed" do
+        let(:message) { build_message(bar_file.path, "no?", 2, 11) }
+        it { is_expected.to eq(7) }
+
+        it "updates annotated_line to match" do
+          expect { update! }.to change { message.annotated_line }.from(nil).to(7)
+        end
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/changed_file_spec.rb
+++ b/spec/quiet_quality/changed_file_spec.rb
@@ -14,4 +14,15 @@ RSpec.describe QuietQuality::ChangedFile do
     it { is_expected.to be_a(Set) }
     it { is_expected.to contain_exactly(1, 3, 5, 9, 10) }
   end
+
+  describe "#line_numbers" do
+    subject { changed_file.line_numbers }
+    it { is_expected.to be_an(Array) }
+    it { is_expected.to eq([1, 3, 5, 9, 10]) }
+
+    context "when the lines are out of order" do
+      let(:lines) { [5, 1, 2, 9, 8] }
+      it { is_expected.to eq([1, 2, 5, 8, 9]) }
+    end
+  end
 end

--- a/spec/quiet_quality/message_spec.rb
+++ b/spec/quiet_quality/message_spec.rb
@@ -67,35 +67,7 @@ RSpec.describe QuietQuality::Message do
   include_examples "field with default", :stop_line, default_binding: :start_line
   include_examples "field with default", :level, default_value: nil
   include_examples "field with default", :rule, default_value: nil
-
-  describe "#annotated_line" do
-    subject { message.annotated_line }
-
-    context "when it is set during initialization" do
-      let(:annotated_line) { 19 }
-      it { is_expected.to eq(19) }
-    end
-
-    context "when it is set later" do
-      let(:annotated_line) { nil }
-      before { message.annotated_line = 44 }
-      it { is_expected.to eq(44) }
-    end
-
-    context "when it is not set" do
-      let(:annotated_line) { nil }
-
-      context "but stop_line is" do
-        let(:stop_line) { 28 }
-        it { is_expected.to eq(28) }
-      end
-
-      context "and neither is stop_line" do
-        let(:stop_line) { nil }
-        it { is_expected.to eq(start_line) }
-      end
-    end
-  end
+  include_examples "field with default", :annotated_line, default_value: nil
 
   describe "#to_h" do
     subject(:to_h) { message.to_h }


### PR DESCRIPTION
This loads the ChangedFiles and then can process one or more Message objects, assigning an `annotated_line` to each (where appropriate).

The rule is essentially "use the last line from the message that was relevant to the diff", so that annotations show up _below_ large blocks of change, rather than after the first line of them. I'm not sure if there is a 'best' rule to use, but these seems least obtrusive - we might want to support configuration of this particular behavior later?

Note that for large code-bases, this bit of code is performance-relevant - naive inclusion tests and comparisons might end up running for each of 20k messages against diffs including several thousand lines of change. There are minor optimizations still available, but I think reverse_each and range-comparison is most of what's needed here.

Resolves #11 