### PR TITLE
Support rubocop

### DIFF
--- a/lib/quiet_quality/tools.rb
+++ b/lib/quiet_quality/tools.rb
@@ -13,6 +13,7 @@ Dir.glob(glob).sort.each { |f| require f }
 module QuietQuality
   module Tools
     AVAILABLE = {
+      rubocop: Rubocop,
       standardrb: Standardrb
     }
   end

--- a/lib/quiet_quality/tools/rubocop.rb
+++ b/lib/quiet_quality/tools/rubocop.rb
@@ -1,0 +1,11 @@
+module QuietQuality
+  module Tools
+    module Rubocop
+      ExecutionError = Class.new(Tools::Error)
+      ParsingError = Class.new(Tools::Error)
+    end
+  end
+end
+
+glob = File.expand_path("../rubocop/*.rb", __FILE__)
+Dir.glob(glob).sort.each { |f| require f }

--- a/lib/quiet_quality/tools/rubocop/parser.rb
+++ b/lib/quiet_quality/tools/rubocop/parser.rb
@@ -1,0 +1,46 @@
+module QuietQuality
+  module Tools
+    module Rubocop
+      class Parser
+        def initialize(text)
+          @text = text
+        end
+
+        def messages
+          return @_messages if defined?(@_messages)
+          messages = content
+            .fetch(:files)
+            .map { |f| messages_for_file(f) }
+            .flatten
+          @_messages = Messages.new(messages)
+        end
+
+        private
+
+        attr_reader :text
+
+        def content
+          @_content ||= JSON.parse(text, symbolize_names: true)
+        end
+
+        def messages_for_file(file_details)
+          path = file_details.fetch(:path)
+          file_details.fetch(:offenses).map do |offense|
+            message_for_offense(path, offense)
+          end
+        end
+
+        def message_for_offense(path, offense)
+          Message.new(
+            path: path,
+            body: offense.fetch(:message),
+            start_line: offense.dig(:location, :start_line),
+            stop_line: offense.dig(:location, :last_line),
+            level: offense.fetch(:severity, nil),
+            rule: offense.fetch(:cop_name, nil)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/quiet_quality/tools/rubocop/runner.rb
+++ b/lib/quiet_quality/tools/rubocop/runner.rb
@@ -1,0 +1,58 @@
+module QuietQuality
+  module Tools
+    module Rubocop
+      class Runner
+        MAX_FILES = 100
+        NO_FILES_OUTPUT = '{"files": [], "summary": {"offense_count": 0}}'
+
+        def command_name
+          "rubocop"
+        end
+
+        # Supplying changed_files: nil means "run against all files".
+        # error_stream is really just injectable for unit-testing purposes.
+        def initialize(changed_files: nil, error_stream: $stderr)
+          @changed_files = changed_files
+          @error_stream = error_stream
+        end
+
+        def invoke!
+          return NO_FILES_OUTPUT if skip_execution?
+          out, err, stat = Open3.capture3(*command)
+          error_stream.write(err)
+          fail(ExecutionError, "Execution of #{command_name} failed with #{stat.exitstatus}") unless stat.success?
+          out
+        end
+
+        private
+
+        attr_reader :changed_files, :error_stream
+
+        # If we were told that _no files changed_ (which is distinct from not being told that
+        # any files changed - a [] instead of a nil), then we shouldn't run rubocop at all.
+        def skip_execution?
+          changed_files && relevant_files.empty?
+        end
+
+        # Note: if target_files goes over MAX_FILES, it's _empty_ instead - that means that
+        # we run against the full repository instead of the specific files (rubocop's behavior
+        # when no target files are specified)
+        def command
+          return nil if skip_execution?
+          [command_name, "-f", "json", "--fail-level", "fatal"] + target_files.sort
+        end
+
+        def relevant_files
+          return nil if changed_files.nil?
+          changed_files.select { |path| path.end_with?(".rb") }
+        end
+
+        def target_files
+          return [] if changed_files.nil?
+          return [] if relevant_files.length > MAX_FILES
+          relevant_files
+        end
+      end
+    end
+  end
+end

--- a/lib/quiet_quality/tools/standardrb.rb
+++ b/lib/quiet_quality/tools/standardrb.rb
@@ -1,3 +1,5 @@
+require_relative "./rubocop"
+
 module QuietQuality
   module Tools
     module Standardrb

--- a/lib/quiet_quality/tools/standardrb/parser.rb
+++ b/lib/quiet_quality/tools/standardrb/parser.rb
@@ -1,45 +1,7 @@
 module QuietQuality
   module Tools
     module Standardrb
-      class Parser
-        def initialize(text)
-          @text = text
-        end
-
-        def messages
-          return @_messages if defined?(@_messages)
-          messages = content
-            .fetch(:files)
-            .map { |f| messages_for_file(f) }
-            .flatten
-          @_messages = Messages.new(messages)
-        end
-
-        private
-
-        attr_reader :text
-
-        def content
-          @_content ||= JSON.parse(text, symbolize_names: true)
-        end
-
-        def messages_for_file(file_details)
-          path = file_details.fetch(:path)
-          file_details.fetch(:offenses).map do |offense|
-            message_for_offense(path, offense)
-          end
-        end
-
-        def message_for_offense(path, offense)
-          Message.new(
-            path: path,
-            body: offense.fetch(:message),
-            start_line: offense.dig(:location, :start_line),
-            stop_line: offense.dig(:location, :last_line),
-            level: offense.fetch(:severity, nil),
-            rule: offense.fetch(:cop_name, nil)
-          )
-        end
+      class Parser < Rubocop::Parser
       end
     end
   end

--- a/lib/quiet_quality/tools/standardrb/runner.rb
+++ b/lib/quiet_quality/tools/standardrb/runner.rb
@@ -1,52 +1,9 @@
 module QuietQuality
   module Tools
     module Standardrb
-      class Runner
-        MAX_FILES = 100
-        NO_FILES_OUTPUT = '{"files": [], "summary": {"offense_count": 0}}'
-
-        # Supplying changed_files: nil means "run against all files".
-        # error_stream is really just injectable for unit-testing purposes.
-        def initialize(changed_files: nil, error_stream: $stderr)
-          @changed_files = changed_files
-          @error_stream = error_stream
-        end
-
-        def invoke!
-          return NO_FILES_OUTPUT if skip_execution?
-          out, err, stat = Open3.capture3(*command)
-          error_stream.write(err)
-          fail(ExecutionError, "Execution of standardrb failed with #{stat.exitstatus}") unless stat.success?
-          out
-        end
-
-        private
-
-        attr_reader :changed_files, :error_stream
-
-        # If we were told that _no files changed_ (which is distinct from not being told that
-        # any files changed - a [] instead of a nil), then we shouldn't run rubocop at all.
-        def skip_execution?
-          changed_files && relevant_files.empty?
-        end
-
-        # Note: if target_files goes over MAX_FILES, it's _empty_ instead - that means that
-        # we run against the full repository instead of the specific files (rubocop's behavior
-        # when no target files are specified)
-        def command
-          return nil if skip_execution?
-          ["standardrb", "-f", "json", "--fail-level", "fatal"] + target_files.sort
-        end
-
-        def relevant_files
-          return nil if changed_files.nil?
-          changed_files.select { |path| path.end_with?(".rb") }
-        end
-
-        def target_files
-          return [] if changed_files.nil?
-          return [] if relevant_files.length > MAX_FILES
-          relevant_files
+      class Runner < Rubocop::Runner
+        def command_name
+          "standardrb"
         end
       end
     end

--- a/spec/fixtures/tools/rubocop/failures.json
+++ b/spec/fixtures/tools/rubocop/failures.json
@@ -1,0 +1,226 @@
+{
+  "metadata": {
+    "rubocop_version": "1.50.2",
+    "ruby_engine": "ruby",
+    "ruby_version": "2.7.6",
+    "ruby_patchlevel": "219",
+    "ruby_platform": "x86_64-darwin22"
+  },
+  "files": [
+    {
+      "path": "Gemfile",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/message.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/messages.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools/standardrb.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools/standardrb/parser.rb",
+      "offenses": [
+        {
+          "severity": "convention",
+          "message": "Style/EmptyMethod: Put the `end` of empty method definitions on the next line.",
+          "cop_name": "Style/EmptyMethod",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 9,
+            "start_column": 9,
+            "last_line": 10,
+            "last_column": 25,
+            "length": 17,
+            "line": 9,
+            "column": 9
+          }
+        },
+        {
+          "severity": "convention",
+          "message": "Style/SingleLineMethods: Avoid single-line method definitions.",
+          "cop_name": "Style/SingleLineMethods",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 9,
+            "start_column": 9,
+            "last_line": 9,
+            "last_column": 25,
+            "length": 17,
+            "line": 9,
+            "column": 9
+          }
+        },
+        {
+          "severity": "convention",
+          "message": "Layout/EmptyLinesAroundMethodBody: Extra empty line detected at method body beginning.",
+          "cop_name": "Layout/EmptyLinesAroundMethodBody",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 20,
+            "start_column": 1,
+            "last_line": 21,
+            "last_column": 1,
+            "length": 1,
+            "line": 20,
+            "column": 1
+          }
+        },
+        {
+          "severity": "convention",
+          "message": "Layout/EmptyLines: Extra blank line detected.",
+          "cop_name": "Layout/EmptyLines",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 21,
+            "start_column": 1,
+            "last_line": 22,
+            "last_column": 1,
+            "length": 1,
+            "line": 21,
+            "column": 1
+          }
+        },
+        {
+          "severity": "convention",
+          "message": "Layout/EmptyLines: Extra blank line detected.",
+          "cop_name": "Layout/EmptyLines",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 22,
+            "start_column": 1,
+            "last_line": 23,
+            "last_column": 1,
+            "length": 1,
+            "line": 22,
+            "column": 1
+          }
+        },
+        {
+          "severity": "convention",
+          "message": "Layout/EmptyLinesAroundMethodBody: Extra empty line detected at method body end.",
+          "cop_name": "Layout/EmptyLinesAroundMethodBody",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 22,
+            "start_column": 1,
+            "last_line": 23,
+            "last_column": 1,
+            "length": 1,
+            "line": 22,
+            "column": 1
+          }
+        }
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools/standardrb/runner.rb",
+      "offenses": [
+        {
+          "severity": "convention",
+          "message": "Layout/ExtraSpacing: Unnecessary spacing detected.",
+          "cop_name": "Layout/ExtraSpacing",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 19,
+            "start_column": 16,
+            "last_line": 19,
+            "last_column": 16,
+            "length": 1,
+            "line": 19,
+            "column": 16
+          }
+        },
+        {
+          "severity": "convention",
+          "message": "Layout/SpaceInsideParens: Space inside parentheses detected.",
+          "cop_name": "Layout/SpaceInsideParens",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 19,
+            "start_column": 16,
+            "last_line": 19,
+            "last_column": 17,
+            "length": 2,
+            "line": 19,
+            "column": 16
+          }
+        }
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/version.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "quiet_quality.gemspec",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/quiet_quality/message_spec.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/quiet_quality/messages_spec.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/spec_helper.rb",
+      "offenses": [
+
+      ]
+    }
+  ],
+  "summary": {
+    "offense_count": 8,
+    "target_file_count": 14,
+    "inspected_file_count": 14
+  }
+}

--- a/spec/fixtures/tools/rubocop/no-failures.json
+++ b/spec/fixtures/tools/rubocop/no-failures.json
@@ -1,0 +1,100 @@
+{
+  "metadata": {
+    "rubocop_version": "1.50.2",
+    "ruby_engine": "ruby",
+    "ruby_version": "2.7.6",
+    "ruby_patchlevel": "219",
+    "ruby_platform": "x86_64-darwin22"
+  },
+  "files": [
+    {
+      "path": "Gemfile",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/message.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/messages.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools/standardrb.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools/standardrb/parser.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/tools/standardrb/runner.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "lib/quiet_quality/version.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "quiet_quality.gemspec",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/quiet_quality/message_spec.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/quiet_quality/messages_spec.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "offenses": [
+
+      ]
+    },
+    {
+      "path": "spec/spec_helper.rb",
+      "offenses": [
+
+      ]
+    }
+  ],
+  "summary": {
+    "offense_count": 0,
+    "target_file_count": 14,
+    "inspected_file_count": 14
+  }
+}

--- a/spec/quiet_quality/tools/rubocop/parser_spec.rb
+++ b/spec/quiet_quality/tools/rubocop/parser_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe QuietQuality::Tools::Rubocop::Parser do
+  subject(:parser) { described_class.new(text) }
+
+  describe "#messages" do
+    let(:text) { fixture_content("tools", "rubocop", "no-failures.json") }
+    subject(:messages) { parser.messages }
+
+    it "is memoized" do
+      first_messages = parser.messages
+      expect(parser.messages.object_id).to eq(first_messages.object_id)
+    end
+
+    context "when there are no offenses" do
+      let(:text) { fixture_content("tools", "rubocop", "no-failures.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+    end
+
+    context "when there are some offenses" do
+      let(:text) { fixture_content("tools", "rubocop", "failures.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+      it { is_expected.not_to be_empty }
+
+      it "has the expected offenses in it" do
+        expect(messages.count).to eq(8)
+        expect(messages.map(&:start_line)).to contain_exactly(9, 9, 20, 21, 22, 22, 19, 19)
+      end
+
+      it "fully populates the messages" do
+        expect(messages.first.path).to eq("lib/quiet_quality/tools/standardrb/parser.rb")
+        expect(messages.first.body).to match(/of empty method definitions on the next line/)
+        expect(messages.first.start_line).to eq(9)
+        expect(messages.first.stop_line).to eq(10)
+        expect(messages.first.stop_line).to eq(10)
+        expect(messages.first.level).to eq("convention")
+        expect(messages.first.rule).to eq("Style/EmptyMethod")
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/tools/rubocop/runner_spec.rb
+++ b/spec/quiet_quality/tools/rubocop/runner_spec.rb
@@ -1,0 +1,84 @@
+RSpec.describe QuietQuality::Tools::Rubocop::Runner do
+  let(:changed_files) { nil }
+  let(:error_stream) { instance_double(IO, write: nil) }
+  subject(:runner) { described_class.new(changed_files: changed_files, error_stream: error_stream) }
+
+  let(:out) { "fake output" }
+  let(:err) { "fake error" }
+  let(:stat) { instance_double(Process::Status, success?: true, exitstatus: 0) }
+  before { allow(Open3).to receive(:capture3).and_return([out, err, stat]) }
+
+  describe "#invoke!" do
+    subject(:invoke!) { runner.invoke! }
+
+    context "when the standardrb command _fails_" do
+      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
+
+      it "raises a Rubocop::ExecutionError" do
+        expect { invoke! }.to raise_error(QuietQuality::Tools::Rubocop::ExecutionError)
+      end
+    end
+
+    context "when changed_files is nil" do
+      let(:changed_files) { nil }
+      it { is_expected.to eq("fake output") }
+
+      it "calls rubocop correctly, with no targets" do
+        invoke!
+        expect(Open3)
+          .to have_received(:capture3)
+          .with("rubocop", "-f", "json", "--fail-level", "fatal")
+      end
+    end
+
+    context "when changed_files is empty" do
+      let(:changed_files) { [] }
+      it { is_expected.to eq(described_class::NO_FILES_OUTPUT) }
+
+      it "does not call rubocop" do
+        invoke!
+        expect(Open3).not_to have_received(:capture3)
+      end
+    end
+
+    context "when changed_files is full" do
+      let(:file1) { "foo.js" }
+      let(:file2) { "bar.rb" }
+      let(:file3) { "baz.rb" }
+      let(:changed_files) { [file1, file2, file3] }
+
+      context "but contains no ruby files" do
+        let(:file2) { "bar.js" }
+        let(:file3) { "baz.ts" }
+
+        it "does not call rubocop" do
+          invoke!
+          expect(Open3).not_to have_received(:capture3)
+        end
+      end
+
+      context "and contains some ruby files" do
+        it { is_expected.to eq("fake output") }
+
+        it "calls rubocop correctly, with changed and relevant targets" do
+          invoke!
+          expect(Open3)
+            .to have_received(:capture3)
+            .with("rubocop", "-f", "json", "--fail-level", "fatal", "bar.rb", "baz.rb")
+        end
+      end
+
+      context "and contains too many ruby files" do
+        before { stub_const("QuietQuality::Tools::Rubocop::Runner::MAX_FILES", 1) }
+        it { is_expected.to eq("fake output") }
+
+        it "calls rubocop correctly, with no targets" do
+          invoke!
+          expect(Open3)
+            .to have_received(:capture3)
+            .with("rubocop", "-f", "json", "--fail-level", "fatal")
+        end
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/tools/standardrb/runner_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/runner_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
     context "when the standardrb command _fails_" do
       let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
 
-      it "raises a Standardrb::ExecutionError" do
-        expect { invoke! }.to raise_error(QuietQuality::Tools::Standardrb::ExecutionError)
+      it "raises a Rubocop::ExecutionError" do
+        expect { invoke! }.to raise_error(QuietQuality::Tools::Rubocop::ExecutionError)
       end
     end
 
@@ -69,7 +69,7 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
       end
 
       context "and contains too many ruby files" do
-        before { stub_const("QuietQuality::Tools::Standardrb::Runner::MAX_FILES", 1) }
+        before { stub_const("QuietQuality::Tools::Rubocop::Runner::MAX_FILES", 1) }
         it { is_expected.to eq("fake output") }
 
         it "calls standardrb correctly, with no targets" do


### PR DESCRIPTION
Since its implementation is pretty much _identical_ to standardrb's, we'll move the implementation from there, and make standardrb's parser/runner just inherit from it, and override the command-name.

Resolves #18 