### PR TITLE
Add Annotations system and initial GHA annotation writer

### DIFF
--- a/lib/quiet_quality/annotators.rb
+++ b/lib/quiet_quality/annotators.rb
@@ -1,7 +1,19 @@
-module QuietQuality
-  module Annotators
-  end
-end
-
 glob = File.expand_path("../annotators/*.rb", __FILE__)
 Dir.glob(glob).sort.each { |f| require(f) }
+
+module QuietQuality
+  module Annotators
+    Unrecognized = Class.new(Error)
+
+    ANNOTATOR_TYPES = {
+      github_stdout: Annotators::GithubStdout
+    }.freeze
+
+    def self.annotate!(annotator:, messages:, limit: nil)
+      limited_messages = limit ? messages.first(limit) : messages
+      ANNOTATOR_TYPES.fetch(annotator.to_sym).new.annotate!(limited_messages)
+    rescue KeyError
+      fail Unrecognized, "Unrecognized annotator_type '#{annotator}'"
+    end
+  end
+end

--- a/lib/quiet_quality/annotators.rb
+++ b/lib/quiet_quality/annotators.rb
@@ -1,0 +1,7 @@
+module QuietQuality
+  module Annotators
+  end
+end
+
+glob = File.expand_path("../annotators/*.rb", __FILE__)
+Dir.glob(glob).sort.each { |f| require(f) }

--- a/lib/quiet_quality/annotators/github_stdout.rb
+++ b/lib/quiet_quality/annotators/github_stdout.rb
@@ -1,0 +1,36 @@
+module QuietQuality
+  module Annotators
+    class GithubStdout
+      # github will only accept the first 10 annotations of each type in this form.
+      MAX_ANNOTATIONS = 10
+
+      def initialize(output_stream: $stdout)
+        @output_stream = output_stream
+      end
+
+      def annotate!(messages)
+        messages.first(MAX_ANNOTATIONS).each do |message|
+          output_stream.puts self.class.format(message)
+        end
+      end
+
+      # Example annotation output from github's docs:
+      # ::warning file={name},line={line},title={title}::{message}
+      # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message
+      def self.format(message)
+        attributes = {
+          file: message.path,
+          line: message.annotated_line || message.start_line,
+          title: message.rule
+        }.compact
+
+        attributes_string = attributes.map { |k, v| "#{k}=#{v}" }.join(",")
+        "::warning #{attributes_string}::#{message.body}"
+      end
+
+      private
+
+      attr_reader :output_stream
+    end
+  end
+end

--- a/spec/quiet_quality/annotators/github_stdout_spec.rb
+++ b/spec/quiet_quality/annotators/github_stdout_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe QuietQuality::Annotators::GithubStdout do
+  let(:fake_stdout) { instance_double(IO, puts: nil) }
+  subject(:annotator) { described_class.new(output_stream: fake_stdout) }
+
+  describe ".format" do
+    let(:message) do
+      QuietQuality::Message.new(
+        path: "foo/bar.rb",
+        body: "My Message",
+        start_line: start_line,
+        annotated_line: annotated_line,
+        rule: rule
+      )
+    end
+    let(:start_line) { 20 }
+    let(:annotated_line) { 25 }
+    let(:rule) { "MyRule" }
+    subject(:formatted_line) { described_class.format(message) }
+
+    context "with annotated_line set" do
+      let(:annotated_line) { 25 }
+      it { is_expected.to eq("::warning file=foo/bar.rb,line=25,title=MyRule::My Message") }
+    end
+
+    context "without annotated_line set" do
+      let(:annotated_line) { nil }
+      it { is_expected.to eq("::warning file=foo/bar.rb,line=20,title=MyRule::My Message") }
+    end
+
+    context "with a rule" do
+      let(:rule) { "MyRule" }
+      it { is_expected.to eq("::warning file=foo/bar.rb,line=25,title=MyRule::My Message") }
+    end
+
+    context "with no rule" do
+      let(:rule) { nil }
+      it { is_expected.to eq("::warning file=foo/bar.rb,line=25::My Message") }
+    end
+  end
+
+  describe "#annotate!" do
+    let(:m1) { QuietQuality::Message.new(path: "foo.rb", body: "Msg1", start_line: 1) }
+    let(:m2) { QuietQuality::Message.new(path: "bar.rb", body: "Msg2", start_line: 2, rule: "Title") }
+    let(:m3) { QuietQuality::Message.new(path: "baz.rb", body: "Msg3", start_line: 3, annotated_line: 5) }
+    let(:messages) { [m1, m2, m3] }
+    subject(:annotate!) { annotator.annotate!(messages) }
+
+    it "writes the expected messages to the output stream" do
+      annotate!
+      expect(fake_stdout).to have_received(:puts).with("::warning file=foo.rb,line=1::Msg1")
+      expect(fake_stdout).to have_received(:puts).with("::warning file=bar.rb,line=2,title=Title::Msg2")
+      expect(fake_stdout).to have_received(:puts).with("::warning file=baz.rb,line=5::Msg3")
+    end
+
+    context "when given more messages than it can annotate" do
+      before { stub_const("QuietQuality::Annotators::GithubStdout::MAX_ANNOTATIONS", 2) }
+
+      it "writes the expected messages to the output stream" do
+        annotate!
+        expect(fake_stdout).to have_received(:puts).with("::warning file=foo.rb,line=1::Msg1")
+        expect(fake_stdout).to have_received(:puts).with("::warning file=bar.rb,line=2,title=Title::Msg2")
+        expect(fake_stdout).not_to have_received(:puts).with("::warning file=baz.rb,line=5::Msg3")
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/annotators_spec.rb
+++ b/spec/quiet_quality/annotators_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe QuietQuality::Annotators do
   describe ".annotate!" do
-    let(:annotator) { :github_stdout }
     let(:limit) { nil }
     let(:messages) { generate_messages(10) }
     subject(:annotate!) { described_class.annotate!(annotator: annotator, messages: messages, limit: limit) }
@@ -13,13 +12,37 @@ RSpec.describe QuietQuality::Annotators do
       end
     end
 
-    context "when the limit isn't set" do
-    end
+    context "for the :github_stdout annotator" do
+      let(:annotator) { :github_stdout }
+      let(:fake_annotator) { instance_double(QuietQuality::Annotators::GithubStdout, annotate!: nil) }
+      before { allow(QuietQuality::Annotators::GithubStdout).to receive(:new).and_return(fake_annotator) }
 
-    context "when the limit is larger than the message count" do
-    end
+      context "when the limit isn't set" do
+        let(:limit) { nil }
 
-    context "when the limit is smaller than the message count" do
+        it "invokes the annotator correctly" do
+          annotate!
+          expect(fake_annotator).to have_received(:annotate!).with(messages)
+        end
+      end
+
+      context "when the limit is larger than the message count" do
+        let(:limit) { 15 }
+
+        it "invokes the annotator correctly" do
+          annotate!
+          expect(fake_annotator).to have_received(:annotate!).with(messages)
+        end
+      end
+
+      context "when the limit is smaller than the message count" do
+        let(:limit) { 3 }
+
+        it "invokes the annotator correctly" do
+          annotate!
+          expect(fake_annotator).to have_received(:annotate!).with(messages.first(3))
+        end
+      end
     end
   end
 end

--- a/spec/quiet_quality/annotators_spec.rb
+++ b/spec/quiet_quality/annotators_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe QuietQuality::Annotators do
+  describe ".annotate!" do
+    let(:annotator) { :github_stdout }
+    let(:limit) { nil }
+    let(:messages) { generate_messages(10) }
+    subject(:annotate!) { described_class.annotate!(annotator: annotator, messages: messages, limit: limit) }
+
+    context "for an unrecognized annotator type" do
+      let(:annotator) { :false_annotator }
+
+      it "raises an UnrecognizedAnnotator" do
+        expect { annotate! }.to raise_error(QuietQuality::Annotators::Unrecognized)
+      end
+    end
+
+    context "when the limit isn't set" do
+    end
+
+    context "when the limit is larger than the message count" do
+    end
+
+    context "when the limit is smaller than the message count" do
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,9 @@ require File.expand_path("../../lib/quiet_quality", __FILE__)
 gem_root = File.expand_path("../..", __FILE__)
 FIXTURES_DIRECTORY = File.join(gem_root, "spec", "fixtures")
 
+support_glob = File.join(gem_root, "spec", "support", "**", "*.rb")
+Dir[support_glob].sort.each { |f| require f }
+
 def fixture_path(*parts)
   File.join(FIXTURES_DIRECTORY, *parts)
 end

--- a/spec/support/message_setup.rb
+++ b/spec/support/message_setup.rb
@@ -1,0 +1,28 @@
+require "securerandom"
+
+module MessageSetup
+  def generate_message_attributes(attrs)
+    start_line = attrs.fetch(:start_line, Random.rand(100))
+    {
+      path: attrs.fetch(:path, "path/#{SecureRandom.alphanumeric(10)}.rb"),
+      body: attrs.fetch(:body, "Fake Message: #{SecureRandom.uuid}"),
+      start_line: start_line,
+      stop_line: attrs.fetch(:stop_line, start_line + Random.rand(4)),
+      annotated_line: attrs.fetch(:annotated_line, nil),
+      level: attrs.fetch(:level, "Moderate"),
+      rule: attrs.fetch(:rule, "FakeRule")
+    }
+  end
+
+  def generate_message(**attrs)
+    QuietQuality::Message.new(**generate_message_attributes(attrs))
+  end
+
+  def generate_messages(count, **attrs)
+    count.times.map { generate_message(**attrs) }
+  end
+end
+
+RSpec.configure do |config|
+  config.include MessageSetup
+end


### PR DESCRIPTION
Add the `QuietQuality::Annotations.annotate!` dispatcher method, and a single implementation, `QuietQuality::Annotations::GithubStdout`, which generates warning annotations via [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message).

This is fairly limiting, but is an extremely easy approach to implement and to use, as long as you're working in github actions. We'll later implement another that annotates using credentials and the github api, which is _less_ limiting (and can annotate more than 10 messages), and there is room for other solutions that annotate onto other systems.

Resolves #22 