### PR TITLE
Support "entirely" changed files

### DIFF
--- a/lib/quiet_quality/annotation_locator.rb
+++ b/lib/quiet_quality/annotation_locator.rb
@@ -18,6 +18,7 @@ module QuietQuality
     attr_reader :changed_files
 
     def file_line_for(message, changed_file)
+      return message.stop_line if changed_file.entire?
       message_range = (message.start_line..message.stop_line)
       last_match(changed_file.line_numbers, message_range)
     end

--- a/lib/quiet_quality/changed_file.rb
+++ b/lib/quiet_quality/changed_file.rb
@@ -4,14 +4,27 @@ module QuietQuality
 
     def initialize(path:, lines:)
       @path = path
-      @lines = lines
+
+      if lines == :all || lines == "all"
+        @entire = true
+        @lines = nil
+      else
+        @entire = false
+        @lines = lines
+      end
+    end
+
+    def entire?
+      @entire
     end
 
     def lines
+      return nil if @lines.nil?
       @_lines ||= @lines.to_set
     end
 
     def line_numbers
+      return nil if @lines.nil?
       @_line_numbers ||= @lines.sort
     end
   end

--- a/spec/quiet_quality/annotation_locator_spec.rb
+++ b/spec/quiet_quality/annotation_locator_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe QuietQuality::AnnotationLocator do
   let(:foo_file) { QuietQuality::ChangedFile.new(path: "path/foo.rb", lines: [1, 2, 3, 5, 10]) }
   let(:bar_file) { QuietQuality::ChangedFile.new(path: "path/bar.rb", lines: [5, 6, 7, 14, 15]) }
-  let(:changed_files) { QuietQuality::ChangedFiles.new([foo_file, bar_file]) }
+  let(:bug_file) { QuietQuality::ChangedFile.new(path: "path/bug.rb", lines: :all) }
+  let(:changed_files) { QuietQuality::ChangedFiles.new([foo_file, bar_file, bug_file]) }
   subject(:locator) { described_class.new(changed_files: changed_files) }
 
   def build_message(path, body, start, stop = nil)
@@ -26,6 +27,14 @@ RSpec.describe QuietQuality::AnnotationLocator do
 
       it "doesn't update annotated_line from nil" do
         expect { update! }.not_to change { message.annotated_line }.from(nil)
+      end
+    end
+
+    context "for a message in a file that was entirely changed" do
+      let(:message) { build_message(bug_file.path, "rah", 10_000, 20_000) }
+
+      it "updates the annotated_line to match" do
+        expect { update! }.to change { message.annotated_line }.from(nil).to(20_000)
       end
     end
 

--- a/spec/quiet_quality/changed_file_spec.rb
+++ b/spec/quiet_quality/changed_file_spec.rb
@@ -9,20 +9,67 @@ RSpec.describe QuietQuality::ChangedFile do
     it { is_expected.to eq(path) }
   end
 
+  describe "#entire?" do
+    subject { changed_file.entire? }
+
+    context "when passed an array of line numbers" do
+      let(:lines) { [1, 3, 5, 9, 10] }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when passed the sentinel value :all" do
+      let(:lines) { :all }
+      it { is_expected.to be_truthy }
+    end
+
+    context "when passed the sentinel value 'all'" do
+      let(:lines) { "all" }
+      it { is_expected.to be_truthy }
+    end
+  end
+
   describe "#lines" do
     subject { changed_file.lines }
-    it { is_expected.to be_a(Set) }
-    it { is_expected.to contain_exactly(1, 3, 5, 9, 10) }
+
+    context "when passed an array of line numbers" do
+      let(:lines) { [1, 3, 5, 9, 10] }
+      it { is_expected.to be_a(Set) }
+      it { is_expected.to contain_exactly(1, 3, 5, 9, 10) }
+    end
+
+    context "when passed the sentinel value :all" do
+      let(:lines) { :all }
+      it { is_expected.to be_nil }
+    end
+
+    context "when passed the sentinel value 'all'" do
+      let(:lines) { "all" }
+      it { is_expected.to be_nil }
+    end
   end
 
   describe "#line_numbers" do
     subject { changed_file.line_numbers }
-    it { is_expected.to be_an(Array) }
-    it { is_expected.to eq([1, 3, 5, 9, 10]) }
 
-    context "when the lines are out of order" do
-      let(:lines) { [5, 1, 2, 9, 8] }
-      it { is_expected.to eq([1, 2, 5, 8, 9]) }
+    context "when passed an array of line numbers" do
+      let(:lines) { [1, 3, 5, 9, 10] }
+      it { is_expected.to be_an(Array) }
+      it { is_expected.to eq([1, 3, 5, 9, 10]) }
+
+      context "when the lines are out of order" do
+        let(:lines) { [5, 1, 2, 9, 8] }
+        it { is_expected.to eq([1, 2, 5, 8, 9]) }
+      end
+    end
+
+    context "when passed the sentinel value :all" do
+      let(:lines) { :all }
+      it { is_expected.to be_nil }
+    end
+
+    context "when passed the sentinel value 'all'" do
+      let(:lines) { "all" }
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/quiet_quality/changed_files_spec.rb
+++ b/spec/quiet_quality/changed_files_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe QuietQuality::ChangedFiles do
   let(:foo_file) { QuietQuality::ChangedFile.new(path: "path/foo.rb", lines: [1, 2, 3, 5, 10]) }
   let(:bar_file) { QuietQuality::ChangedFile.new(path: "path/bar.rb", lines: [5, 6, 7, 14, 15]) }
+  let(:bug_file) { QuietQuality::ChangedFile.new(path: "path/bug.py", lines: :all) }
   let(:files) { [foo_file, bar_file] }
   subject(:changed_files) { described_class.new(files) }
 


### PR DESCRIPTION
The system doesn't _actually_ have a need to enumerate the changed lines of changed files, and in some cases that can get silly. So update the ChangedFile abstraction to support an `entire?` method - if you initialize it with `lines: :all`, then it won't bother handling individual lines, and instead will treat any line it's asked about as having been changed (without worrying about whether it even _exists_).