### PR TITLE
Support merging ChangedFiles objects

### DIFF
--- a/lib/quiet_quality/changed_file.rb
+++ b/lib/quiet_quality/changed_file.rb
@@ -33,8 +33,8 @@ module QuietQuality
         fail ArgumentError, "Cannot merge ChangedFiles '#{path}' and '#{other.path}', they're different files"
       end
 
-      return self.class.new(path: path, lines: :all) if entire? || other.entire?
-      self.class.new(path: path, lines: (lines + other.lines).to_a)
+      new_lines = entire? || other.entire? ? :all : (lines + other.lines).to_a
+      self.class.new(path: path, lines: new_lines)
     end
   end
 end

--- a/lib/quiet_quality/changed_file.rb
+++ b/lib/quiet_quality/changed_file.rb
@@ -27,5 +27,14 @@ module QuietQuality
       return nil if @lines.nil?
       @_line_numbers ||= @lines.sort
     end
+
+    def merge(other)
+      if path != other.path
+        fail ArgumentError, "Cannot merge ChangedFiles '#{path}' and '#{other.path}', they're different files"
+      end
+
+      return self.class.new(path: path, lines: :all) if entire? || other.entire?
+      self.class.new(path: path, lines: (lines + other.lines).to_a)
+    end
   end
 end

--- a/lib/quiet_quality/changed_file.rb
+++ b/lib/quiet_quality/changed_file.rb
@@ -33,7 +33,7 @@ module QuietQuality
         fail ArgumentError, "Cannot merge ChangedFiles '#{path}' and '#{other.path}', they're different files"
       end
 
-      new_lines = entire? || other.entire? ? :all : (lines + other.lines).to_a
+      new_lines = (entire? || other.entire?) ? :all : (lines + other.lines).to_a
       self.class.new(path: path, lines: new_lines)
     end
   end

--- a/lib/quiet_quality/changed_files.rb
+++ b/lib/quiet_quality/changed_files.rb
@@ -14,6 +14,14 @@ module QuietQuality
       files_by_path.include?(path)
     end
 
+    def merge(other)
+      merged_files = []
+      (files + other.files)
+        .group_by(&:path)
+        .each_pair { |_path, pfiles| merged_files << pfiles.reduce(&:merge) }
+      self.class.new(merged_files)
+    end
+
     private
 
     def files_by_path

--- a/spec/quiet_quality/changed_file_spec.rb
+++ b/spec/quiet_quality/changed_file_spec.rb
@@ -72,4 +72,53 @@ RSpec.describe QuietQuality::ChangedFile do
       it { is_expected.to be_nil }
     end
   end
+
+  describe "#merge" do
+    subject { changed_file.merge(other) }
+
+    context "when the two files have different paths" do
+      let(:other) { described_class.new(path: "/wrong", lines: [5, 7, 9]) }
+
+      it "raises an ArgumentError" do
+        expect { subject }.to raise_error(ArgumentError, /Cannot merge/)
+      end
+    end
+
+    context "when the first file is 'entire'" do
+      let(:lines) { :all }
+      let(:other) { described_class.new(path: path, lines: [5, 7]) }
+      it { is_expected.to be_a(described_class) }
+      it { is_expected.to be_entire }
+
+      it "has the expected path" do
+        expect(subject.path).to eq(path)
+      end
+    end
+
+    context "when the second file is 'entire'" do
+      let(:other) { described_class.new(path: path, lines: :all) }
+      it { is_expected.to be_a(described_class) }
+      it { is_expected.to be_entire }
+
+      it "has the expected path" do
+        expect(subject.path).to eq(path)
+      end
+    end
+
+    context "when the lists of lines overlap" do
+      let(:other) { described_class.new(path: path, lines: [5, 6, 7, 64]) }
+      it { is_expected.to be_a(described_class) }
+      it { is_expected.not_to be_entire }
+
+      it "has the expected path" do
+        expect(subject.path).to eq(path)
+      end
+
+      it "has the expected lines" do
+        expect(subject.lines).to contain_exactly(1, 3, 5, 6, 7, 9, 10, 64)
+        expect(subject.lines).to be_a(Set)
+        expect(subject.line_numbers).to be_an(Array)
+      end
+    end
+  end
 end

--- a/spec/quiet_quality/changed_files_spec.rb
+++ b/spec/quiet_quality/changed_files_spec.rb
@@ -2,12 +2,12 @@ RSpec.describe QuietQuality::ChangedFiles do
   let(:foo_file) { QuietQuality::ChangedFile.new(path: "path/foo.rb", lines: [1, 2, 3, 5, 10]) }
   let(:bar_file) { QuietQuality::ChangedFile.new(path: "path/bar.rb", lines: [5, 6, 7, 14, 15]) }
   let(:bug_file) { QuietQuality::ChangedFile.new(path: "path/bug.py", lines: :all) }
-  let(:files) { [foo_file, bar_file] }
+  let(:files) { [foo_file, bar_file, bug_file] }
   subject(:changed_files) { described_class.new(files) }
 
   describe "#files" do
     subject { changed_files.files }
-    it { is_expected.to contain_exactly(foo_file, bar_file) }
+    it { is_expected.to contain_exactly(foo_file, bar_file, bug_file) }
   end
 
   describe "#file" do
@@ -35,6 +35,29 @@ RSpec.describe QuietQuality::ChangedFiles do
     context "for a path that doesn't match any file" do
       let(:path) { "path/baz.js" }
       it { is_expected.to be_falsey }
+    end
+  end
+
+  describe "#merge" do
+    subject { changed_files.merge(other) }
+
+    let(:foo2) { QuietQuality::ChangedFile.new(path: "path/foo.rb", lines: [4, 5, 8]) }
+    let(:bug2) { QuietQuality::ChangedFile.new(path: "path/bug.py", lines: [14, 44]) }
+    let(:baz2) { QuietQuality::ChangedFile.new(path: "path/baz.rb", lines: [1, 2, 3]) }
+    let(:other) { described_class.new([foo2, bug2, baz2]) }
+
+    it { is_expected.to be_a(described_class) }
+
+    it "includes the right paths" do
+      expect(subject.files.map(&:path))
+        .to contain_exactly("path/foo.rb", "path/bar.rb", "path/bug.py", "path/baz.rb")
+    end
+
+    it "has merged those files as expected" do
+      expect(subject.file("path/foo.rb").lines).to contain_exactly(1, 2, 3, 4, 5, 8, 10)
+      expect(subject.file("path/bar.rb").lines).to contain_exactly(5, 6, 7, 14, 15)
+      expect(subject.file("path/bug.py")).to be_entire
+      expect(subject.file("path/baz.rb").lines).to contain_exactly(1, 2, 3)
     end
   end
 end


### PR DESCRIPTION
To simplify some other systems that need to merge together change-sets (from a git-diff, git-staged, and git-uncommitted, for example), we can implement merging within the ChangedFile and ChangedFiles abstractions fairly easily. Then combining those change-sets becomes trivial inside the Git subsystem.