### PR TITLE
Support Rspec as a 'tool'

### DIFF
--- a/lib/quiet_quality/tools.rb
+++ b/lib/quiet_quality/tools.rb
@@ -13,6 +13,7 @@ Dir.glob(glob).sort.each { |f| require f }
 module QuietQuality
   module Tools
     AVAILABLE = {
+      rspec: Rspec,
       rubocop: Rubocop,
       standardrb: Standardrb
     }

--- a/lib/quiet_quality/tools/rspec.rb
+++ b/lib/quiet_quality/tools/rspec.rb
@@ -1,0 +1,11 @@
+module QuietQuality
+  module Tools
+    module Rspec
+      ExecutionError = Class.new(Tools::Error)
+      ParsingError = Class.new(Tools::Error)
+    end
+  end
+end
+
+glob = File.expand_path("../rspec/*.rb", __FILE__)
+Dir.glob(glob).sort.each { |f| require f }

--- a/lib/quiet_quality/tools/rspec/parser.rb
+++ b/lib/quiet_quality/tools/rspec/parser.rb
@@ -1,0 +1,45 @@
+module QuietQuality
+  module Tools
+    module Rspec
+      class Parser
+        def initialize(text)
+          @text = text
+        end
+
+        def messages
+          return @_messages if defined?(@_messages)
+          messages = failed_examples.map { |ex| message_for(ex) }
+          @_messages = Messages.new(messages)
+        end
+
+        private
+
+        attr_reader :text
+
+        def content
+          @_content ||= JSON.parse(text, symbolize_names: true)
+        end
+
+        def examples
+          @_examples ||= content.fetch(:examples)
+        end
+
+        def failed_examples
+          @_failed_examples ||= examples.select { |ex| ex[:status] == "failed" }
+        end
+
+        def reduced_path(path)
+          path.gsub(%r{^\./}, "")
+        end
+
+        def message_for(example)
+          path = reduced_path(example.fetch(:file_path))
+          body = example.dig(:exception, :message) || example.fetch(:description)
+          line = example.fetch(:line_number)
+          rule = example.dig(:exception, :class) || "Failed Example"
+          Message.new(path: path, body: body, start_line: line, rule: rule)
+        end
+      end
+    end
+  end
+end

--- a/lib/quiet_quality/tools/rspec/runner.rb
+++ b/lib/quiet_quality/tools/rspec/runner.rb
@@ -1,0 +1,47 @@
+module QuietQuality
+  module Tools
+    module Rspec
+      class Runner
+        MAX_FILES = 100
+        NO_FILES_OUTPUT = '{"examples": [], "summary": {"failure_count": 0}}'
+
+        def initialize(changed_files: nil, error_stream: $stderr)
+          @changed_files = changed_files
+          @error_stream = error_stream
+        end
+
+        def invoke!
+          return NO_FILES_OUTPUT if skip_execution?
+          out, err, stat = Open3.capture3(*command)
+          error_stream.write(err)
+          fail(ExecutionError, "Execution of rspec failed with #{stat.exitstatus}") unless stat.success?
+          out
+        end
+
+        private
+
+        attr_reader :changed_files, :error_stream
+
+        def skip_execution?
+          changed_files && relevant_files.empty?
+        end
+
+        def relevant_files
+          return nil if changed_files.nil?
+          changed_files.select { |path| path.end_with?("_spec.rb") }
+        end
+
+        def target_files
+          return [] if changed_files.nil?
+          return [] if relevant_files.length > MAX_FILES
+          relevant_files
+        end
+
+        def command
+          return nil if skip_execution?
+          ["rspec", "--failure-exit-code", "0", "-f", "json"] + target_files.sort
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/tools/rspec/failures.json
+++ b/spec/fixtures/tools/rspec/failures.json
@@ -1,0 +1,53 @@
+{
+  "version": "3.12.2",
+  "seed": 34337,
+  "examples": [
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:3:2]",
+      "description": "calls standardrb correctly, with no targets",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full and contains too many ruby files calls standardrb correctly, with no targets",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 75,
+      "run_time": 0.00024,
+      "pending_message": null
+    },
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:3:1]",
+      "description": "is expected to eq \"wrong fake output\"",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full and contains too many ruby files is expected to eq \"wrong fake output\"",
+      "status": "failed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 73,
+      "run_time": 0.004895,
+      "pending_message": null
+    },
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:1:1]",
+      "description": "does not call standardrb",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full but contains no ruby files does not call standardrb",
+      "status": "failed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 54,
+      "run_time": 0.000199,
+      "pending_message": null,
+      "exception": {
+        "class": "RSpec::Expectations::ExpectationNotMetError",
+        "message": "(Open3).capture3(*(any args))\n    expected: 1 time with any arguments\n    received: 0 times with any arguments",
+        "backtrace": [
+          "/Users/emueller/.rvm/gems/ruby-3.1.2@qq/gems/rspec-support-3.12.0/lib/rspec/support.rb:102:in `block in <module:Support>'",
+          "/Users/emueller/.rvm/gems/ruby-3.1.2@qq/gems/rspec-core-3.12.2/lib/rspec/core/example_group.rb:608:in `map'",
+          "/Users/emueller/.rvm/gems/ruby-3.1.2@qq/bin/ruby_executable_hooks:22:in `<main>'"
+        ]
+      }
+    }
+  ],
+  "summary": {
+    "duration": 0.010737,
+    "example_count": 3,
+    "failure_count": 2,
+    "pending_count": 0,
+    "errors_outside_of_examples_count": 0
+  },
+  "summary_line": "10 examples, 2 failures"
+}

--- a/spec/fixtures/tools/rspec/no-failures.json
+++ b/spec/fixtures/tools/rspec/no-failures.json
@@ -1,0 +1,44 @@
+{
+  "version": "3.12.2",
+  "seed": 64304,
+  "examples": [
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:3:2]",
+      "description": "calls standardrb correctly, with no targets",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full and contains too many ruby files calls standardrb correctly, with no targets",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 75,
+      "run_time": 0.000185,
+      "pending_message": null
+    },
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:1:1]",
+      "description": "does not call standardrb",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full but contains no ruby files does not call standardrb",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 54,
+      "run_time": 0.000125,
+      "pending_message": null
+    },
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:2:2]",
+      "description": "calls standardrb correctly, with changed and relevant targets",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full and contains some ruby files calls standardrb correctly, with changed and relevant targets",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 63,
+      "run_time": 0.000148,
+      "pending_message": null
+    }
+  ],
+  "summary": {
+    "duration": 0.018751,
+    "example_count": 3,
+    "failure_count": 0,
+    "pending_count": 0,
+    "errors_outside_of_examples_count": 0
+  },
+  "summary_line": "89 examples, 0 failures"
+}

--- a/spec/quiet_quality/tools/rspec/parser_spec.rb
+++ b/spec/quiet_quality/tools/rspec/parser_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe QuietQuality::Tools::Rspec::Parser do
+  subject(:parser) { described_class.new(text) }
+
+  describe "#messages" do
+    let(:text) { fixture_content("tools", "rspec", "no-failures.json") }
+    subject(:messages) { parser.messages }
+
+    it "is memoized" do
+      first_messages = parser.messages
+      expect(parser.messages.object_id).to eq(first_messages.object_id)
+    end
+
+
+    context "when there are no offenses" do
+      let(:text) { fixture_content("tools", "rspec", "no-failures.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+      it { is_expected.to be_empty }
+    end
+
+    context "when there are some offenses" do
+      let(:text) { fixture_content("tools", "rspec", "failures.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+      it { is_expected.not_to be_empty }
+
+      it "has the expected offenses in it" do
+        expect(messages.count).to eq(2)
+        expect(messages.map(&:start_line)).to contain_exactly(73, 54)
+      end
+
+      it "properly populates the messages when there is an exception present" do
+        m = messages.detect { |msg| msg.start_line == 54 }
+        expect(m.path).to eq("spec/quiet_quality/tools/standardrb/runner_spec.rb")
+        expect(m.start_line).to eq(54)
+        expect(m.rule).to eq("RSpec::Expectations::ExpectationNotMetError")
+        expect(m.body).to eq(<<~MESSAGE.strip)
+          (Open3).capture3(*(any args))
+              expected: 1 time with any arguments
+              received: 0 times with any arguments
+        MESSAGE
+      end
+
+      it "properly populates the message when no exception is present" do
+        m = messages.detect { |msg| msg.start_line == 73 }
+        expect(m.path)
+        expect(m.path).to eq("spec/quiet_quality/tools/standardrb/runner_spec.rb")
+        expect(m.start_line).to eq(73)
+        expect(m.rule).to eq("Failed Example")
+        expect(m.body).to eq("is expected to eq \"wrong fake output\"")
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/tools/rspec/parser_spec.rb
+++ b/spec/quiet_quality/tools/rspec/parser_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe QuietQuality::Tools::Rspec::Parser do
       expect(parser.messages.object_id).to eq(first_messages.object_id)
     end
 
-
     context "when there are no offenses" do
       let(:text) { fixture_content("tools", "rspec", "no-failures.json") }
       it { is_expected.to be_a(QuietQuality::Messages) }

--- a/spec/quiet_quality/tools/rspec/runner_spec.rb
+++ b/spec/quiet_quality/tools/rspec/runner_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe QuietQuality::Tools::Rspec::Runner do
+  let(:changed_files) { nil }
+  let(:error_stream) { instance_double(IO, write: nil) }
+  subject(:runner) { described_class.new(changed_files: changed_files, error_stream: error_stream) }
+
+  let(:out) { "fake output" }
+  let(:err) { "fake error" }
+  let(:stat) { instance_double(Process::Status, success?: true, exitstatus: 0) }
+  before { allow(Open3).to receive(:capture3).and_return([out, err, stat]) }
+
+  describe "#invoke!" do
+    subject(:invoke!) { runner.invoke! }
+
+    context "when the rspec command fails" do
+      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
+
+      it "raises an Rspec::ExecutionError" do
+        expect { invoke! }.to raise_error(QuietQuality::Tools::Rspec::ExecutionError)
+      end
+    end
+
+    context "when changed_files is nil" do
+      let(:changed_files) { nil }
+      it { is_expected.to eq("fake output") }
+
+      it "calls rspec with no targets" do
+        invoke!
+        expect(Open3)
+          .to have_received(:capture3)
+          .with("rspec", "--failure-exit-code", "0", "-f", "json")
+      end
+    end
+
+    context "when changed_files is empty" do
+      let(:changed_files) { [] }
+      it { is_expected.to eq(described_class::NO_FILES_OUTPUT) }
+
+      it "does not call rspec" do
+        expect(Open3).not_to have_received(:capture3)
+      end
+    end
+
+    context "when changed_files is full" do
+      context "but contains no spec files" do
+        let(:changed_files) { ["foo_spec.ts", "bar.rb", "baz_spec.rb.bak"] }
+        it { is_expected.to eq(described_class::NO_FILES_OUTPUT) }
+
+        it "does not call rspec" do
+          expect(Open3).not_to have_received(:capture3)
+        end
+      end
+
+      context "and contains some spec files" do
+        let(:changed_files) { ["foo_spec.ts", "bar_spec.rb", "baz_spec.rb.bak", "a/alpha_spec.rb"] }
+        it { is_expected.to eq("fake output") }
+
+        it "calls rspec with no targets" do
+          invoke!
+          expect(Open3)
+            .to have_received(:capture3)
+            .with("rspec", "--failure-exit-code", "0", "-f", "json", "a/alpha_spec.rb", "bar_spec.rb")
+        end
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/tools/standardrb/parser_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/parser_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe QuietQuality::Tools::Standardrb::Parser do
     context "when there are no offenses" do
       let(:text) { fixture_content("tools", "standardrb", "no-failures.json") }
       it { is_expected.to be_a(QuietQuality::Messages) }
+      it { is_expected.to be_empty }
     end
 
     context "when there are some offenses" do


### PR DESCRIPTION
Support rspec as a tool alongside rubocop and standardrb. Ideally, every tool that you'd like to run to confirm that your commit or code are 'good' you can run with a single `qq` invocation, and `rspec` is certainly one of those!

Resolves #23 