### PR TITLE
Expose runner outcomes more thoroughly

### DIFF
--- a/bin/qq
+++ b/bin/qq
@@ -2,24 +2,24 @@
 
 require_relative "../lib/quiet_quality"
 
-tools =
-  if ARGV.empty?
-    @tools = QuietQuality::Tools::AVAILABLE.values
-  else
-    @tools = ARGV.map { |t| QuietQuality::Tools::AVAILABLE.fetch(t.to_sym) }
-  end
+tool_names = ARGV.empty? ? QuietQuality::Tools::AVAILABLE.keys : ARGV.map(&:to_sym)
 
-tools.each do |tool|
-  warn "================ Running tool #{tool}"
+tool_names.each do |tool_name|
+  tool = QuietQuality::Tools::AVAILABLE.fetch(tool_name)
+  warn "================ Running #{tool_name}"
   runner = tool::Runner.new
-  output = runner.invoke!
+  outcome = runner.invoke!
 
-  parser = tool::Parser.new(output)
-  messages = parser.messages
-  warn "#{messages.count} messages\n"
-  messages.each do |msg|
-    warn "  #{msg.path}:#{msg.start_line}-#{msg.stop_line}    #{msg.rule}"
-    warn "      #{msg.body}"
+  if outcome.success?
+    warn "No problems found!\n\n"
+  else
+    parser = tool::Parser.new(outcome.output)
+    messages = parser.messages
+    warn "#{messages.count} messages\n"
+    messages.each do |msg|
+      warn "  #{msg.path}:#{msg.start_line}-#{msg.stop_line}    #{msg.rule}"
+      warn "      #{msg.body}"
+    end
+    warn "\n"
   end
-  warn "\n"
 end

--- a/bin/qq
+++ b/bin/qq
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+require_relative "../lib/quiet_quality"
+
+tools =
+  if ARGV.empty?
+    @tools = QuietQuality::Tools::AVAILABLE.values
+  else
+    @tools = ARGV.map { |t| QuietQuality::Tools::AVAILABLE.fetch(t.to_sym) }
+  end
+
+tools.each do |tool|
+  warn "================ Running tool #{tool}"
+  runner = tool::Runner.new
+  output = runner.invoke!
+
+  parser = tool::Parser.new(output)
+  messages = parser.messages
+  warn "#{messages.count} messages\n"
+  messages.each do |msg|
+    warn "  #{msg.path}:#{msg.start_line}-#{msg.stop_line}    #{msg.rule}"
+    warn "      #{msg.body}"
+  end
+  warn "\n"
+end

--- a/lib/quiet_quality/tools/outcome.rb
+++ b/lib/quiet_quality/tools/outcome.rb
@@ -1,0 +1,25 @@
+module QuietQuality
+  module Tools
+    class Outcome
+      attr_reader :output, :logging
+
+      def initialize(output:, logging: nil, failure: false)
+        @output = output
+        @logging = logging
+        @failure = failure
+      end
+
+      def failure?
+        @failure
+      end
+
+      def success?
+        !failure?
+      end
+
+      def ==(other)
+        output == other.output && logging == other.logging && failure? == other.failure?
+      end
+    end
+  end
+end

--- a/lib/quiet_quality/tools/rspec/runner.rb
+++ b/lib/quiet_quality/tools/rspec/runner.rb
@@ -34,7 +34,7 @@ module QuietQuality
 
         def command
           return nil if skip_execution?
-          ["rspec", "--failure-exit-code", "0", "-f", "json"] + target_files.sort
+          ["rspec", "-f", "json"] + target_files.sort
         end
 
         def skipped_outcome

--- a/spec/quiet_quality/tools/outcome_spec.rb
+++ b/spec/quiet_quality/tools/outcome_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe QuietQuality::Tools::Outcome do
+  let(:failure) { false }
+  let(:output) { "fake output" }
+  let(:logging) { "fake logging" }
+  subject(:outcome) { described_class.new(output: output, logging: logging, failure: failure) }
+
+  describe "#failure?" do
+    subject(:failure?) { outcome.failure? }
+
+    context "when failure: true" do
+      let(:failure) { true }
+      it { is_expected.to be_truthy }
+    end
+
+    context "when failure: false" do
+      let(:failure) { false }
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe "#success?" do
+    subject(:success?) { outcome.success? }
+
+    context "when failure: true" do
+      let(:failure) { true }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when failure: false" do
+      let(:failure) { false }
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe "#==" do
+    let(:other) { build_outcome(output: other_output, logging: other_logging, failure: other_failure) }
+    subject(:equality) { outcome == other }
+
+    let(:other_output) { output }
+    let(:other_logging) { logging }
+    let(:other_failure) { failure }
+
+    context "when all match" do
+      it { is_expected.to be_truthy }
+    end
+
+    context "when output is different" do
+      let(:other_output) { output + "\n" }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when logging is different" do
+      let(:other_logging) { "foo" }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when failure? is different" do
+      let(:other_failure) { !failure }
+      it { is_expected.to be_falsey }
+    end
+  end
+end

--- a/spec/quiet_quality/tools/rspec/runner_spec.rb
+++ b/spec/quiet_quality/tools/rspec/runner_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
       end
     end
 
+    context "when the rspec _tests_ fail" do
+      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 1) }
+      it { is_expected.to eq(build_failure("fake output", "fake error")) }
+
+      it "calls rspec with no targets" do
+        invoke!
+        expect(Open3)
+          .to have_received(:capture3)
+          .with("rspec", "-f", "json")
+      end
+    end
+
     context "when changed_files is nil" do
       let(:changed_files) { nil }
       it { is_expected.to eq(build_success("fake output", "fake error")) }
@@ -26,7 +38,7 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
         invoke!
         expect(Open3)
           .to have_received(:capture3)
-          .with("rspec", "--failure-exit-code", "0", "-f", "json")
+          .with("rspec", "-f", "json")
       end
     end
 
@@ -57,7 +69,7 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
           invoke!
           expect(Open3)
             .to have_received(:capture3)
-            .with("rspec", "--failure-exit-code", "0", "-f", "json", "a/alpha_spec.rb", "bar_spec.rb")
+            .with("rspec", "-f", "json", "a/alpha_spec.rb", "bar_spec.rb")
         end
       end
     end

--- a/spec/quiet_quality/tools/rspec/runner_spec.rb
+++ b/spec/quiet_quality/tools/rspec/runner_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe QuietQuality::Tools::Rspec::Runner do
   let(:changed_files) { nil }
-  let(:error_stream) { instance_double(IO, write: nil) }
-  subject(:runner) { described_class.new(changed_files: changed_files, error_stream: error_stream) }
+  subject(:runner) { described_class.new(changed_files: changed_files) }
 
   let(:out) { "fake output" }
   let(:err) { "fake error" }
@@ -21,7 +20,7 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
 
     context "when changed_files is nil" do
       let(:changed_files) { nil }
-      it { is_expected.to eq("fake output") }
+      it { is_expected.to eq(build_success("fake output", "fake error")) }
 
       it "calls rspec with no targets" do
         invoke!
@@ -33,7 +32,7 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
 
     context "when changed_files is empty" do
       let(:changed_files) { [] }
-      it { is_expected.to eq(described_class::NO_FILES_OUTPUT) }
+      it { is_expected.to eq(build_success(described_class::NO_FILES_OUTPUT)) }
 
       it "does not call rspec" do
         expect(Open3).not_to have_received(:capture3)
@@ -43,7 +42,7 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
     context "when changed_files is full" do
       context "but contains no spec files" do
         let(:changed_files) { ["foo_spec.ts", "bar.rb", "baz_spec.rb.bak"] }
-        it { is_expected.to eq(described_class::NO_FILES_OUTPUT) }
+        it { is_expected.to eq(build_success(described_class::NO_FILES_OUTPUT)) }
 
         it "does not call rspec" do
           expect(Open3).not_to have_received(:capture3)
@@ -52,7 +51,7 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
 
       context "and contains some spec files" do
         let(:changed_files) { ["foo_spec.ts", "bar_spec.rb", "baz_spec.rb.bak", "a/alpha_spec.rb"] }
-        it { is_expected.to eq("fake output") }
+        it { is_expected.to eq(build_success("fake output", "fake error")) }
 
         it "calls rspec with no targets" do
           invoke!

--- a/spec/quiet_quality/tools/rubocop/runner_spec.rb
+++ b/spec/quiet_quality/tools/rubocop/runner_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe QuietQuality::Tools::Rubocop::Runner do
   let(:changed_files) { nil }
-  let(:error_stream) { instance_double(IO, write: nil) }
-  subject(:runner) { described_class.new(changed_files: changed_files, error_stream: error_stream) }
+  subject(:runner) { described_class.new(changed_files: changed_files) }
 
   let(:out) { "fake output" }
   let(:err) { "fake error" }
@@ -21,19 +20,19 @@ RSpec.describe QuietQuality::Tools::Rubocop::Runner do
 
     context "when changed_files is nil" do
       let(:changed_files) { nil }
-      it { is_expected.to eq("fake output") }
+      it { is_expected.to eq(build_success("fake output", "fake error")) }
 
       it "calls rubocop correctly, with no targets" do
         invoke!
         expect(Open3)
           .to have_received(:capture3)
-          .with("rubocop", "-f", "json", "--fail-level", "fatal")
+          .with("rubocop", "-f", "json")
       end
     end
 
     context "when changed_files is empty" do
       let(:changed_files) { [] }
-      it { is_expected.to eq(described_class::NO_FILES_OUTPUT) }
+      it { is_expected.to eq(build_success(described_class::NO_FILES_OUTPUT)) }
 
       it "does not call rubocop" do
         invoke!
@@ -58,25 +57,25 @@ RSpec.describe QuietQuality::Tools::Rubocop::Runner do
       end
 
       context "and contains some ruby files" do
-        it { is_expected.to eq("fake output") }
+        it { is_expected.to eq(build_success("fake output", "fake error")) }
 
         it "calls rubocop correctly, with changed and relevant targets" do
           invoke!
           expect(Open3)
             .to have_received(:capture3)
-            .with("rubocop", "-f", "json", "--fail-level", "fatal", "bar.rb", "baz.rb")
+            .with("rubocop", "-f", "json", "bar.rb", "baz.rb")
         end
       end
 
       context "and contains too many ruby files" do
         before { stub_const("QuietQuality::Tools::Rubocop::Runner::MAX_FILES", 1) }
-        it { is_expected.to eq("fake output") }
+        it { is_expected.to eq(build_success("fake output", "fake error")) }
 
         it "calls rubocop correctly, with no targets" do
           invoke!
           expect(Open3)
             .to have_received(:capture3)
-            .with("rubocop", "-f", "json", "--fail-level", "fatal")
+            .with("rubocop", "-f", "json")
         end
       end
     end

--- a/spec/quiet_quality/tools/rubocop/runner_spec.rb
+++ b/spec/quiet_quality/tools/rubocop/runner_spec.rb
@@ -10,11 +10,21 @@ RSpec.describe QuietQuality::Tools::Rubocop::Runner do
   describe "#invoke!" do
     subject(:invoke!) { runner.invoke! }
 
-    context "when the standardrb command _fails_" do
+    context "when the rubocop command _fails_" do
       let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
 
       it "raises a Rubocop::ExecutionError" do
         expect { invoke! }.to raise_error(QuietQuality::Tools::Rubocop::ExecutionError)
+      end
+    end
+
+    context "when the rubocop command _finds problems_" do
+      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 1) }
+      it { is_expected.to eq(build_failure("fake output", "fake error")) }
+
+      it "calls rubocop correctly, with no targets" do
+        invoke!
+        expect(Open3).to have_received(:capture3).with("rubocop", "-f", "json")
       end
     end
 
@@ -24,9 +34,7 @@ RSpec.describe QuietQuality::Tools::Rubocop::Runner do
 
       it "calls rubocop correctly, with no targets" do
         invoke!
-        expect(Open3)
-          .to have_received(:capture3)
-          .with("rubocop", "-f", "json")
+        expect(Open3).to have_received(:capture3).with("rubocop", "-f", "json")
       end
     end
 

--- a/spec/quiet_quality/tools/standardrb/runner_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/runner_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
       end
     end
 
+    context "when the standardrb command _finds problems_" do
+      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 1) }
+      it { is_expected.to eq(build_failure("fake output", "fake error")) }
+
+      it "calls standardrb correctly, with no targets" do
+        invoke!
+        expect(Open3).to have_received(:capture3).with("standardrb", "-f", "json")
+      end
+    end
+
     context "when changed_files is nil" do
       let(:changed_files) { nil }
       it { is_expected.to eq(build_success("fake output", "fake error")) }

--- a/spec/quiet_quality/tools/standardrb/runner_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/runner_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe QuietQuality::Tools::Standardrb::Runner do
   let(:changed_files) { nil }
-  let(:error_stream) { instance_double(IO, write: nil) }
-  subject(:runner) { described_class.new(changed_files: changed_files, error_stream: error_stream) }
+  subject(:runner) { described_class.new(changed_files: changed_files) }
 
   let(:out) { "fake output" }
   let(:err) { "fake error" }
@@ -21,19 +20,19 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
 
     context "when changed_files is nil" do
       let(:changed_files) { nil }
-      it { is_expected.to eq("fake output") }
+      it { is_expected.to eq(build_success("fake output", "fake error")) }
 
       it "calls standardrb correctly, with no targets" do
         invoke!
         expect(Open3)
           .to have_received(:capture3)
-          .with("standardrb", "-f", "json", "--fail-level", "fatal")
+          .with("standardrb", "-f", "json")
       end
     end
 
     context "when changed_files is empty" do
       let(:changed_files) { [] }
-      it { is_expected.to eq(described_class::NO_FILES_OUTPUT) }
+      it { is_expected.to eq(build_success(described_class::NO_FILES_OUTPUT)) }
 
       it "does not call standardrb" do
         invoke!
@@ -58,25 +57,25 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
       end
 
       context "and contains some ruby files" do
-        it { is_expected.to eq("fake output") }
+        it { is_expected.to eq(build_success("fake output", "fake error")) }
 
         it "calls standardrb correctly, with changed and relevant targets" do
           invoke!
           expect(Open3)
             .to have_received(:capture3)
-            .with("standardrb", "-f", "json", "--fail-level", "fatal", "bar.rb", "baz.rb")
+            .with("standardrb", "-f", "json", "bar.rb", "baz.rb")
         end
       end
 
       context "and contains too many ruby files" do
         before { stub_const("QuietQuality::Tools::Rubocop::Runner::MAX_FILES", 1) }
-        it { is_expected.to eq("fake output") }
+        it { is_expected.to eq(build_success("fake output", "fake error")) }
 
         it "calls standardrb correctly, with no targets" do
           invoke!
           expect(Open3)
             .to have_received(:capture3)
-            .with("standardrb", "-f", "json", "--fail-level", "fatal")
+            .with("standardrb", "-f", "json")
         end
       end
     end

--- a/spec/support/outcome_setup.rb
+++ b/spec/support/outcome_setup.rb
@@ -1,0 +1,17 @@
+module OutcomeSetup
+  def build_outcome(output:, logging: nil, failure: false)
+    QuietQuality::Tools::Outcome.new(output: output, logging: logging, failure: failure)
+  end
+
+  def build_success(output, logging = nil)
+    build_outcome(output: output, logging: logging, failure: false)
+  end
+
+  def build_failure(output, logging = nil)
+    build_outcome(output: output, logging: logging, failure: true)
+  end
+end
+
+RSpec.configure do |config|
+  config.include OutcomeSetup
+end


### PR DESCRIPTION
Rather than (a) using successful statuses for "problems found", (b) raising exceptions on an unsuccessful execution, and (c) returning a string output from the runners.. add a new QQ::Tools::Outcome abstraction, which holds the output, logging, and _success/failure_ of a runner execution, and update the runners to each return one of _those_ (which also simplifies away the optional error-stream parameters).

Now we can have the tools return their usual exit statuses (all of the _current_ tools use a status of 1 to indicate "the tool ran successfully, but found problems), and only raise an _exception_ if we get some other status out of the tool - a failing spec isn't exceptional, it's an expected outcome.

Incidentally, add an initial `bin/qq` script, which just takes a list of tools to run (or runs them all), because that makes exercising this stuff much simpler. And it's already very useful :-)