### PR TITLE
Use QQ on itself

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -1,0 +1,30 @@
+name: QuietQuality Itself
+
+on: [push]
+
+jobs:
+  QuietQuality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+
+      - name: Cache gems
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-dogfood-${{ hashFiles('Gemfile.lock') }}
+          restore-keys:
+            ${{ runner.os }}-dogfood-
+
+      - name: Install gems
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Run QuietQuality
+        run: bundle exec bin/qq standardrb rubocop rspec
+        env:
+          ANNOTATOR: github_stdout

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,7 +6,7 @@ jobs:
   StandardRB:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
@@ -14,7 +14,7 @@ jobs:
           ruby-version: 3.2
 
       - name: Cache gems
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-linters-${{ hashFiles('Gemfile.lock') }}

--- a/bin/qq
+++ b/bin/qq
@@ -3,12 +3,14 @@
 require_relative "../lib/quiet_quality"
 
 tool_names = ARGV.empty? ? QuietQuality::Tools::AVAILABLE.keys : ARGV.map(&:to_sym)
+outcomes = []
 
 tool_names.each do |tool_name|
   tool = QuietQuality::Tools::AVAILABLE.fetch(tool_name)
   warn "================ Running #{tool_name}"
   runner = tool::Runner.new
   outcome = runner.invoke!
+  outcomes << outcome
 
   if outcome.success?
     warn "No problems found!\n\n"
@@ -22,4 +24,9 @@ tool_names.each do |tool_name|
     end
     warn "\n"
   end
+end
+
+if outcomes.any? { |o| o.failure? }
+  warn "failures detected in one or more tools"
+  exit(1)
 end

--- a/bin/qq
+++ b/bin/qq
@@ -17,12 +17,18 @@ tool_names.each do |tool_name|
   else
     parser = tool::Parser.new(outcome.output)
     messages = parser.messages
+
     warn "#{messages.count} messages\n"
     messages.each do |msg|
       warn "  #{msg.path}:#{msg.start_line}-#{msg.stop_line}    #{msg.rule}"
       warn "      #{msg.body}"
     end
     warn "\n"
+
+    if ENV.fetch("ANNOTATOR", nil) == "github_stdout"
+      QuietQuality::Annotators::GithubStdout.new.annotate!(messages)
+    end
+
   end
 end
 


### PR DESCRIPTION
Add a github action to execute QuietQuality against itself, and get those sweet annotations flowing :-)

* Update `bin/qq` to _fail_ if any of the tools encountered an issue (produced a `failed?` Outcome)
* Run the annotator after each tool if the env `ANNOTATOR` is set to `github_stdout` (this is temporary, until #34 gets implemented)
* Update linters.yml to use `checkout@v3` and `cache@v3` (deprecation warnings about node)
* Add a `dogfood.yml` github workflow that runs QQ against itself

You can see some resulting annotations from [this diff](https://github.com/nevinera/quiet_quality/compare/nev-7--use-qq-in-gha-on-itself...nev-7--use-qq-in-gha-on-itself--with-problems?): 
<img width="1231" alt="Screen Shot 2023-05-06 at 11 17 29 PM" src="https://user-images.githubusercontent.com/366133/236655793-d54a38f2-0686-45b8-9ecd-703f03d1e4e8.png">
