### PR TITLE
Use ChangedFiles to limit runner targets

### DIFF
--- a/lib/quiet_quality/changed_files.rb
+++ b/lib/quiet_quality/changed_files.rb
@@ -6,6 +6,10 @@ module QuietQuality
       @files = files
     end
 
+    def paths
+      @_paths ||= files.map(&:path)
+    end
+
     def file(path)
       files_by_path.fetch(path, nil)
     end

--- a/lib/quiet_quality/cli/option_parser.rb
+++ b/lib/quiet_quality/cli/option_parser.rb
@@ -83,6 +83,10 @@ module QuietQuality
         parser.on("-c", "--changed-files [tool]", "Use the tool(s) only on changed files") do |tool|
           read_tool_or_global_option(:all_files, tool, false)
         end
+
+        parser.on("-B", "--comparison-branch BRANCH", "Specify the branch to compare against") do |branch|
+          @options[:comparison_branch] = branch
+        end
       end
 
       def setup_filter_messages_options(parser)

--- a/lib/quiet_quality/cli/options.rb
+++ b/lib/quiet_quality/cli/options.rb
@@ -5,10 +5,11 @@ module QuietQuality
         @annotator = nil
         @executor = Executors::ConcurrentExecutor
         @tools = nil
+        @comparison_branch = nil
       end
 
       attr_reader :annotator, :executor
-      attr_accessor :tools
+      attr_accessor :tools, :comparison_branch
 
       def annotator=(name)
         @annotator = Annotators::ANNOTATOR_TYPES.fetch(name.to_sym)

--- a/lib/quiet_quality/cli/options_builder.rb
+++ b/lib/quiet_quality/cli/options_builder.rb
@@ -12,6 +12,7 @@ module QuietQuality
         options = Options.new
         set_unless_nil(options, :annotator, @raw_global_options[:annotator])
         set_unless_nil(options, :executor, @raw_global_options[:executor])
+        set_unless_nil(options, :comparison_branch, @raw_global_options[:comparison_branch])
         options.tools = tool_names.map { |tool_name| tool_options_for(tool_name) }
         @_options = options
       end

--- a/lib/quiet_quality/tools/rspec/runner.rb
+++ b/lib/quiet_quality/tools/rspec/runner.rb
@@ -23,7 +23,7 @@ module QuietQuality
 
         def relevant_files
           return nil if changed_files.nil?
-          changed_files.select { |path| path.end_with?("_spec.rb") }
+          changed_files.paths.select { |path| path.end_with?("_spec.rb") }
         end
 
         def target_files

--- a/lib/quiet_quality/tools/rubocop/runner.rb
+++ b/lib/quiet_quality/tools/rubocop/runner.rb
@@ -38,7 +38,7 @@ module QuietQuality
 
         def relevant_files
           return nil if changed_files.nil?
-          changed_files.select { |path| path.end_with?(".rb") }
+          changed_files.paths.select { |path| path.end_with?(".rb") }
         end
 
         def target_files

--- a/lib/quiet_quality/version.rb
+++ b/lib/quiet_quality/version.rb
@@ -1,3 +1,3 @@
 module QuietQuality
-  VERSION = "0.0.1"
+  VERSION = "0.1.0"
 end

--- a/lib/quiet_quality/version_control_systems.rb
+++ b/lib/quiet_quality/version_control_systems.rb
@@ -1,5 +1,6 @@
 module QuietQuality
   module VersionControlSystems
+    Error = Class.new(QuietQuality::Error)
   end
 end
 

--- a/spec/quiet_quality/changed_files_spec.rb
+++ b/spec/quiet_quality/changed_files_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe QuietQuality::ChangedFiles do
     it { is_expected.to contain_exactly(foo_file, bar_file, bug_file) }
   end
 
+  describe "#paths" do
+    subject { changed_files.paths }
+    it { is_expected.to contain_exactly("path/foo.rb", "path/bar.rb", "path/bug.py") }
+  end
+
   describe "#file" do
     subject { changed_files.file(path) }
 

--- a/spec/quiet_quality/cli/option_parser_spec.rb
+++ b/spec/quiet_quality/cli/option_parser_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe QuietQuality::Cli::OptionParser do
             -G, --annotate-github-stdout     Annotate with GitHub Workflow commands
             -a, --all-files [tool]           Use the tool(s) on all files
             -c, --changed-files [tool]       Use the tool(s) only on changed files
+            -B, --comparison-branch BRANCH   Specify the branch to compare against
             -f, --filter-messages [tool]     Filter messages from tool(s) based on changed lines
             -u, --unfiltered [tool]          Don't filter messages from tool(s)
       HELP_OUTPUT
@@ -95,6 +96,10 @@ RSpec.describe QuietQuality::Cli::OptionParser do
     expect_all_files("--all-files standardrb", ["--all-files", "standardrb"], globally: nil, standardrb: true, rubocop: nil, rspec: nil)
     expect_all_files("-a -crspec", ["-a", "-crspec"], globally: true, rspec: false, standardrb: nil, rubocop: nil)
     expect_all_files("-arspec -crubocop", ["-arspec", "-crubocop"], globally: nil, rspec: true, rubocop: false, standardrb: nil)
+
+    expect_options("nothing", [], global: {comparison_branch: nil})
+    expect_options("--comparison-branch trunk", ["--comparison-branch", "trunk"], global: {comparison_branch: "trunk"})
+    expect_options("-Btrunk", ["-Btrunk"], global: {comparison_branch: "trunk"})
   end
 
   describe "filtering options" do

--- a/spec/quiet_quality/cli/options_builder_spec.rb
+++ b/spec/quiet_quality/cli/options_builder_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe QuietQuality::Cli::OptionsBuilder do
       end
     end
 
+    describe "#comparison_branch" do
+      subject(:comparison_branch) { options.comparison_branch }
+
+      context "when global_options[:comparison_branch] is unset" do
+        let(:global_options) { {} }
+        it { is_expected.to be_nil }
+      end
+
+      context "when global_options[:comparison_branch] is specified" do
+        let(:global_options) { {comparison_branch: "my-comparison-branch"} }
+        it { is_expected.to eq("my-comparison-branch") }
+      end
+    end
+
     describe "#tools" do
       subject(:tools) { options.tools }
 

--- a/spec/quiet_quality/cli/options_spec.rb
+++ b/spec/quiet_quality/cli/options_spec.rb
@@ -1,6 +1,19 @@
 RSpec.describe QuietQuality::Cli::Options do
   subject(:options) { described_class.new }
 
+  describe "#comparison_branch" do
+    subject(:comparison_branch) { options.comparison_branch }
+
+    context "when not set" do
+      it { is_expected.to be_nil }
+    end
+
+    context "when set" do
+      before { options.comparison_branch = "my-branch" }
+      it { is_expected.to eq("my-branch") }
+    end
+  end
+
   describe "#annotator" do
     subject(:annotator) { options.annotator }
     it { is_expected.to be_nil }

--- a/spec/quiet_quality/tools/rspec/runner_spec.rb
+++ b/spec/quiet_quality/tools/rspec/runner_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
     end
 
     context "when changed_files is empty" do
-      let(:changed_files) { [] }
+      let(:changed_files) { empty_changed_files }
       it { is_expected.to eq(build_success(:rspec, described_class::NO_FILES_OUTPUT)) }
 
       it "does not call rspec" do
@@ -53,7 +53,7 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
 
     context "when changed_files is full" do
       context "but contains no spec files" do
-        let(:changed_files) { ["foo_spec.ts", "bar.rb", "baz_spec.rb.bak"] }
+        let(:changed_files) { generate_changed_files({"foo_spec.ts" => :all, "bar.rb" => [1, 2], "baz_spec.rb.bak" => [5]}) }
         it { is_expected.to eq(build_success(:rspec, described_class::NO_FILES_OUTPUT)) }
 
         it "does not call rspec" do
@@ -62,7 +62,8 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
       end
 
       context "and contains some spec files" do
-        let(:changed_files) { ["foo_spec.ts", "bar_spec.rb", "baz_spec.rb.bak", "a/alpha_spec.rb"] }
+        let(:changed_paths) { ["foo_spec.ts", "bar_spec.rb", "baz_spec.rb.bak", "a/alpha_spec.rb"] }
+        let(:changed_files) { generate_changed_files(changed_paths.map { |p| [p, :all] }.to_h) }
         it { is_expected.to eq(build_success(:rspec, "fake output", "fake error")) }
 
         it "calls rspec with no targets" do

--- a/spec/quiet_quality/tools/rubocop/runner_spec.rb
+++ b/spec/quiet_quality/tools/rubocop/runner_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe QuietQuality::Tools::Rubocop::Runner do
     end
 
     context "when changed_files is empty" do
-      let(:changed_files) { [] }
+      let(:changed_files) { empty_changed_files }
       it { is_expected.to eq(build_success(:rubocop, described_class::NO_FILES_OUTPUT)) }
 
       it "does not call rubocop" do
@@ -52,7 +52,7 @@ RSpec.describe QuietQuality::Tools::Rubocop::Runner do
       let(:file1) { "foo.js" }
       let(:file2) { "bar.rb" }
       let(:file3) { "baz.rb" }
-      let(:changed_files) { [file1, file2, file3] }
+      let(:changed_files) { fully_changed_files(file1, file2, file3) }
 
       context "but contains no ruby files" do
         let(:file2) { "bar.js" }

--- a/spec/quiet_quality/tools/standardrb/runner_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/runner_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
     end
 
     context "when changed_files is empty" do
-      let(:changed_files) { [] }
+      let(:changed_files) { empty_changed_files }
       it { is_expected.to eq(build_success(:standardrb, described_class::NO_FILES_OUTPUT)) }
 
       it "does not call standardrb" do
@@ -54,7 +54,7 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
       let(:file1) { "foo.js" }
       let(:file2) { "bar.rb" }
       let(:file3) { "baz.rb" }
-      let(:changed_files) { [file1, file2, file3] }
+      let(:changed_files) { fully_changed_files(file1, file2, file3) }
 
       context "but contains no ruby files" do
         let(:file2) { "bar.js" }

--- a/spec/support/changed_files_setup.rb
+++ b/spec/support/changed_files_setup.rb
@@ -1,0 +1,22 @@
+module ChangedFilesSetup
+  def generate_changed_file(path:, lines:)
+    QuietQuality::ChangedFile.new(path: path, lines: lines)
+  end
+
+  def generate_changed_files(pairs)
+    changed_file_objects = pairs.map { |path, lines| generate_changed_file(path: path, lines: lines) }
+    QuietQuality::ChangedFiles.new(changed_file_objects)
+  end
+
+  def fully_changed_files(*paths)
+    generate_changed_files(paths.map { |p| [p, :all] }.to_h)
+  end
+
+  def empty_changed_files
+    QuietQuality::ChangedFiles.new([])
+  end
+end
+
+RSpec.configure do |config|
+  config.include ChangedFilesSetup
+end


### PR DESCRIPTION
First, it turns out that git-ruby has a _serious_ bug with its implementation of `status.untracked`, which causes it to return all of the ignored files (and all of the contents of the .git directory, for some reason?). From the issue tracker, it seems unlikely to be resolved soon (or easily), so we'll just work around it - it's actually pretty easy to get the specific data we want from the cli directly.

Replace `git.status.untracked` with an Open3 call to `Open3.capture3("git", "-C", path, "ls-files", "--others", "--exclude-standard")`, which produces the exact list of files we want.

Then, add a configuration option allowing us to specify the comparison branch on the command-line, because asking github for it takes nearly a _second_, and I can't spare that kind of time! But seriously, it basically doubles the duration of `bin/qq` on this repo, which feels very not-good. So - for now, run it with `bin/qq -Bmain` for the full performance (or alias that). Later on, the config file can hold that information as easily.

Thirdly, actually grab the ChangedFiles in bin/qq, and feed them into the Executor. Actually _executing_ the script this way quickly pointed out that, when I implemented the runners, the ChangedFile abstraction hadn't existed yet, and I expected the `changed_files` parameters to receive an array of path strings, which.. they _don't_. So, fix that by (a) exposing `ChangedFiles#paths` and then using it in the runners.

But updating all the tests for that change did prompt me to include some test-setup helpers for building ChangedFiles objects...

So yeah. Read this by commit, it'll be way less confusing that way -.-