### PR TITLE
Factor a ParsedOptions interchange class out

### DIFF
--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -13,8 +13,7 @@ module QuietQuality
         unless @parsed
           @parsed_options.help_text = parser.to_s
           parser.parse!(@args)
-          # the parser pulls flags _out_ of @args when it uses them, and leaves the positionals.
-          @parsed_options.tools = @args.dup
+          @parsed_options.tools = validated_tool_names(@args.dup)
           @parsed = true
         end
         @parsed_options
@@ -33,6 +32,10 @@ module QuietQuality
       def validate_value_from(name, value, allowed)
         return if allowed.include?(value.to_sym)
         fail(UsageError, "Unrecognized #{name}: #{value}")
+      end
+
+      def validated_tool_names(names)
+        names.each { |name| validate_value_from("tool", name, Tools::AVAILABLE) }
       end
 
       # There are several flags that _may_ take a 'tool' argument - if they do, they are tool

--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -11,12 +11,15 @@ module QuietQuality
 
       def parsed_options
         unless @parsed
-          @parsed_options.help_text = parser.to_s
           parser.parse!(@args)
           @parsed_options.tools = validated_tool_names(@args.dup)
           @parsed = true
         end
         @parsed_options
+      end
+
+      def help_text
+        @_help_text ||= parser.to_s
       end
 
       private

--- a/lib/quiet_quality/cli/entrypoint.rb
+++ b/lib/quiet_quality/cli/entrypoint.rb
@@ -28,8 +28,12 @@ module QuietQuality
 
       attr_reader :argv, :output_stream, :error_stream
 
+      def arg_parser
+        @_arg_parser ||= ArgParser.new(argv.dup)
+      end
+
       def parsed_options
-        @_parsed_options ||= ArgParser.new(argv.dup).parsed_options
+        @_parsed_options ||= arg_parser.parsed_options
       end
 
       def helping?
@@ -37,7 +41,7 @@ module QuietQuality
       end
 
       def log_help_text
-        error_stream.puts(parsed_options.help_text)
+        error_stream.puts(arg_parser.help_text)
       end
 
       def options

--- a/lib/quiet_quality/cli/entrypoint.rb
+++ b/lib/quiet_quality/cli/entrypoint.rb
@@ -8,30 +8,42 @@ module QuietQuality
       end
 
       def execute
-        executed
-        log_outcomes
-        log_messages
-        annotate_messages
+        if helping?
+          log_help_text
+        else
+          executed
+          log_outcomes
+          log_messages
+          annotate_messages
+        end
+
         self
       end
 
       def successful?
-        !executed.any_failure?
+        helping? || !executed.any_failure?
       end
 
       private
 
       attr_reader :argv, :output_stream, :error_stream
 
-      def option_parser
-        @_option_parser ||= ArgParser.new(argv.dup)
+      def parsed_options
+        @_parsed_options ||= ArgParser.new(argv.dup).parsed_options
+      end
+
+      def helping?
+        parsed_options.helping?
+      end
+
+      def log_help_text
+        error_stream.puts(parsed_options.help_text)
       end
 
       def options
         return @_options if defined?(@_options)
-        tool_names, global_options, tool_options = option_parser.parse!
-        optbuilder = Config::Builder.new(tool_names: tool_names, global_options: global_options, tool_options: tool_options)
-        @_options = optbuilder.options
+        builder = Config::Builder.new(parsed_cli_options: parsed_options)
+        @_options = builder.options
       end
 
       def executor

--- a/lib/quiet_quality/config/builder.rb
+++ b/lib/quiet_quality/config/builder.rb
@@ -7,11 +7,8 @@ module QuietQuality
 
       def options
         return @_options if defined?(@_options)
-        options = Options.new
-        set_annotator(options)
-        set_executor(options)
-        set_unless_nil(options, :comparison_branch, cli.global_option(:comparison_branch))
-        options.tools = tool_names.map { |tool_name| tool_options_for(tool_name) }
+        options = build_initial_options
+        Updater.new(options: options, apply: cli).update!
         @_options = options
       end
 
@@ -19,19 +16,9 @@ module QuietQuality
 
       attr_reader :cli
 
-      def set_unless_nil(object, method, value)
-        return if value.nil?
-        object.send("#{method}=", value)
-      end
-
-      def tool_options_for(tool_name)
-        ToolOptions.new(tool_name).tap do |tool_options|
-          set_unless_nil(tool_options, :limit_targets, cli.global_option(:limit_targets))
-          set_unless_nil(tool_options, :limit_targets, cli.tool_option(tool_name, :limit_targets))
-
-          set_unless_nil(tool_options, :filter_messages, cli.global_option(:filter_messages))
-          set_unless_nil(tool_options, :filter_messages, cli.tool_option(tool_name, :filter_messages))
-        end
+      def build_initial_options
+        tools = tool_names.map { |name| ToolOptions.new(name) }
+        Options.new.tap { |opts| opts.tools = tools }
       end
 
       def tool_names
@@ -42,16 +29,63 @@ module QuietQuality
         end
       end
 
-      def set_annotator(options)
-        annotator_name = cli.global_option(:annotator)
-        return if annotator_name.nil?
-        options.annotator = Annotators::ANNOTATOR_TYPES.fetch(annotator_name)
-      end
+      class Updater
+        def initialize(options:, apply:)
+          @options, @apply = options, apply
+        end
 
-      def set_executor(options)
-        executor_name = cli.global_option(:executor)
-        return if executor_name.nil?
-        options.executor = Executors::AVAILABLE.fetch(executor_name)
+        def update!
+          update_globals
+          update_tools
+        end
+
+        private
+
+        attr_reader :options, :apply
+
+        def set_unless_nil(object, method, value)
+          return if value.nil?
+          object.send("#{method}=", value)
+        end
+
+        # ---- update the global options -------------
+
+        def update_globals
+          update_annotator
+          update_executor
+          update_comparison_branch
+        end
+
+        def update_annotator
+          annotator_name = apply.global_option(:annotator)
+          return if annotator_name.nil?
+          options.annotator = Annotators::ANNOTATOR_TYPES.fetch(annotator_name)
+        end
+
+        def update_executor
+          executor_name = apply.global_option(:executor)
+          return if executor_name.nil?
+          options.executor = Executors::AVAILABLE.fetch(executor_name)
+        end
+
+        def update_comparison_branch
+          set_unless_nil(options, :comparison_branch, apply.global_option(:comparison_branch))
+        end
+
+        # ---- update the tool options (apply global forms first) -------
+
+        def update_tools
+          options.tools.each do |tool_options|
+            update_tool_option(tool_options, :limit_targets)
+            update_tool_option(tool_options, :filter_messages)
+          end
+        end
+
+        def update_tool_option(tool_options, option_name)
+          tool_name = tool_options.tool_name
+          set_unless_nil(tool_options, option_name, apply.global_option(option_name))
+          set_unless_nil(tool_options, option_name, apply.tool_option(tool_name, option_name))
+        end
       end
     end
   end

--- a/lib/quiet_quality/config/builder.rb
+++ b/lib/quiet_quality/config/builder.rb
@@ -1,10 +1,8 @@
 module QuietQuality
   module Config
     class Builder
-      def initialize(tool_names:, global_options:, tool_options:)
-        @raw_tool_names = tool_names
-        @raw_global_options = global_options
-        @raw_tool_options = tool_options
+      def initialize(parsed_cli_options:)
+        @cli = parsed_cli_options
       end
 
       def options
@@ -12,12 +10,14 @@ module QuietQuality
         options = Options.new
         set_annotator(options)
         set_executor(options)
-        set_unless_nil(options, :comparison_branch, @raw_global_options[:comparison_branch])
+        set_unless_nil(options, :comparison_branch, cli.global_option(:comparison_branch))
         options.tools = tool_names.map { |tool_name| tool_options_for(tool_name) }
         @_options = options
       end
 
       private
+
+      attr_reader :cli
 
       def set_unless_nil(object, method, value)
         return if value.nil?
@@ -25,32 +25,31 @@ module QuietQuality
       end
 
       def tool_options_for(tool_name)
-        raw_tool_opts = @raw_tool_options.fetch(tool_name.to_sym, {})
         ToolOptions.new(tool_name).tap do |tool_options|
-          set_unless_nil(tool_options, :limit_targets, @raw_global_options[:limit_targets])
-          set_unless_nil(tool_options, :limit_targets, raw_tool_opts[:limit_targets])
+          set_unless_nil(tool_options, :limit_targets, cli.global_option(:limit_targets))
+          set_unless_nil(tool_options, :limit_targets, cli.tool_option(tool_name, :limit_targets))
 
-          set_unless_nil(tool_options, :filter_messages, @raw_global_options[:filter_messages])
-          set_unless_nil(tool_options, :filter_messages, raw_tool_opts[:filter_messages])
+          set_unless_nil(tool_options, :filter_messages, cli.global_option(:filter_messages))
+          set_unless_nil(tool_options, :filter_messages, cli.tool_option(tool_name, :filter_messages))
         end
       end
 
       def tool_names
-        if @raw_tool_names.empty?
+        if cli.tools.empty?
           Tools::AVAILABLE.keys
         else
-          @raw_tool_names.map(&:to_sym)
+          cli.tools.map(&:to_sym)
         end
       end
 
       def set_annotator(options)
-        annotator_name = @raw_global_options[:annotator]
+        annotator_name = cli.global_option(:annotator)
         return if annotator_name.nil?
         options.annotator = Annotators::ANNOTATOR_TYPES.fetch(annotator_name)
       end
 
       def set_executor(options)
-        executor_name = @raw_global_options[:executor]
+        executor_name = cli.global_option(:executor)
         return if executor_name.nil?
         options.executor = Executors::AVAILABLE.fetch(executor_name)
       end

--- a/lib/quiet_quality/config/parsed_options.rb
+++ b/lib/quiet_quality/config/parsed_options.rb
@@ -8,7 +8,7 @@ module QuietQuality
         @helping = false
       end
 
-      attr_accessor :tools, :help_text
+      attr_accessor :tools
       attr_writer :helping
 
       def helping?

--- a/lib/quiet_quality/config/parsed_options.rb
+++ b/lib/quiet_quality/config/parsed_options.rb
@@ -1,0 +1,36 @@
+module QuietQuality
+  module Config
+    class ParsedOptions
+      def initialize
+        @tools = []
+        @tool_options = {}
+        @global_options = {}
+        @helping = false
+      end
+
+      attr_accessor :tools, :help_text
+      attr_writer :helping
+
+      def helping?
+        @helping
+      end
+
+      def set_global_option(name, value)
+        @global_options[name.to_sym] = value
+      end
+
+      def global_option(name)
+        @global_options.fetch(name.to_sym, nil)
+      end
+
+      def set_tool_option(tool, name, value)
+        @tool_options[tool.to_sym] ||= {}
+        @tool_options[tool.to_sym][name.to_sym] = value
+      end
+
+      def tool_option(tool, name)
+        @tool_options.dig(tool.to_sym, name.to_sym)
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -33,37 +33,38 @@ RSpec.describe QuietQuality::Cli::ArgParser do
     end
   end
 
+  describe "#help_text" do
+    let(:args) { [] }
+    subject(:help_text) { parser.help_text }
+
+    it "exposes the correct content" do
+      expect(help_text).to eq(<<~HELP_OUTPUT)
+        Usage: qq [TOOLS] [GLOBAL_OPTIONS] [TOOL_OPTIONS]
+            -h, --help                       Prints this help
+            -E, --executor EXECUTOR          Which executor to use
+            -A, --annotate ANNOTATOR         Annotate with this annotator
+            -G, --annotate-github-stdout     Annotate with GitHub Workflow commands
+            -a, --all-files [tool]           Use the tool(s) on all files
+            -c, --changed-files [tool]       Use the tool(s) only on changed files
+            -B, --comparison-branch BRANCH   Specify the branch to compare against
+            -f, --filter-messages [tool]     Filter messages from tool(s) based on changed lines
+            -u, --unfiltered [tool]          Don't filter messages from tool(s)
+      HELP_OUTPUT
+    end
+  end
+
   describe "#parsed_options" do
     subject(:parsed_options) { parser.parsed_options }
 
     describe "help option" do
-      shared_examples "exposes the correct help text" do
-        it "exposes the correct help text" do
-          expect(parsed_options.help_text).to eq(<<~HELP_OUTPUT)
-            Usage: qq [TOOLS] [GLOBAL_OPTIONS] [TOOL_OPTIONS]
-                -h, --help                       Prints this help
-                -E, --executor EXECUTOR          Which executor to use
-                -A, --annotate ANNOTATOR         Annotate with this annotator
-                -G, --annotate-github-stdout     Annotate with GitHub Workflow commands
-                -a, --all-files [tool]           Use the tool(s) on all files
-                -c, --changed-files [tool]       Use the tool(s) only on changed files
-                -B, --comparison-branch BRANCH   Specify the branch to compare against
-                -f, --filter-messages [tool]     Filter messages from tool(s) based on changed lines
-                -u, --unfiltered [tool]          Don't filter messages from tool(s)
-          HELP_OUTPUT
-        end
-      end
-
       context "without --help passed" do
         let(:args) { ["-a"] }
         it { is_expected.not_to be_helping }
-        include_examples "exposes the correct help text"
       end
 
       context "with --help passed" do
         let(:args) { ["-a", "--help"] }
         it { is_expected.to be_helping }
-        include_examples "exposes the correct help text"
       end
     end
 

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -84,6 +84,14 @@ RSpec.describe QuietQuality::Cli::ArgParser do
         let(:args) { ["-a", "-u", "rspec", "rspec", "-c", "standardrb", "standardrb"] }
         it { is_expected.to eq(["rspec", "standardrb"]) }
       end
+
+      context "when invalid tool names are supplied" do
+        let(:args) { ["rspec", "foo", "a"] }
+
+        it "raises a UsageError" do
+          expect { parsed }.to raise_error(QuietQuality::Cli::UsageError, /Unrecognized tool/)
+        end
+      end
     end
 
     describe "executor options" do

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -1,17 +1,13 @@
 RSpec.describe QuietQuality::Cli::ArgParser do
   let(:parser) { described_class.new(args) }
-  let(:parsed) { parser.parse! }
-  let(:parsed_positionals) { parsed[0] }
-  let(:parsed_options) { parsed[1] }
-  let(:parsed_tool_options) { parsed[2] }
+  let(:parsed) { parser.parsed_options }
 
   def expect_global_options(**opts)
-    opts.each_pair { |name, value| expect(parsed_options[name]).to eq(value) }
+    opts.each_pair { |name, value| expect(parsed.global_option(name)).to eq(value) }
   end
 
   def expect_tool_options(tool, opts)
-    tool_options = parsed_tool_options[tool] || {}
-    opts.each_pair { |name, value| expect(tool_options[name]).to eq(value) }
+    opts.each_pair { |name, value| expect(parsed.tool_option(tool, name)).to eq(value) }
   end
 
   def self.expect_options(desc, arguments, global: {}, **tools)
@@ -32,99 +28,129 @@ RSpec.describe QuietQuality::Cli::ArgParser do
       let(:args) { arguments }
 
       it "raises a UsageError" do
-        expect { parser.parse! }.to raise_error(QuietQuality::Cli::UsageError, matcher)
+        expect { parsed }.to raise_error(QuietQuality::Cli::UsageError, matcher)
       end
     end
   end
 
-  describe "help option" do
-    let(:args) { ["--help"] }
+  describe "#parsed_options" do
+    subject(:parsed_options) { parser.parsed_options }
 
-    it "sets exit_immediately to true" do
-      expect(parsed_options[:exit_immediately]).to be_truthy
+    describe "help option" do
+      shared_examples "exposes the correct help text" do
+        it "exposes the correct help text" do
+          expect(parsed_options.help_text).to eq(<<~HELP_OUTPUT)
+            Usage: qq [TOOLS] [GLOBAL_OPTIONS] [TOOL_OPTIONS]
+                -h, --help                       Prints this help
+                -E, --executor EXECUTOR          Which executor to use
+                -A, --annotate ANNOTATOR         Annotate with this annotator
+                -G, --annotate-github-stdout     Annotate with GitHub Workflow commands
+                -a, --all-files [tool]           Use the tool(s) on all files
+                -c, --changed-files [tool]       Use the tool(s) only on changed files
+                -B, --comparison-branch BRANCH   Specify the branch to compare against
+                -f, --filter-messages [tool]     Filter messages from tool(s) based on changed lines
+                -u, --unfiltered [tool]          Don't filter messages from tool(s)
+          HELP_OUTPUT
+        end
+      end
+
+      context "without --help passed" do
+        let(:args) { ["-a"] }
+        it { is_expected.not_to be_helping }
+        include_examples "exposes the correct help text"
+      end
+
+      context "with --help passed" do
+        let(:args) { ["-a", "--help"] }
+        it { is_expected.to be_helping }
+        include_examples "exposes the correct help text"
+      end
     end
 
-    it "sets the output as expected" do
-      parser.parse!
-      expect(parser.output).to eq(<<~HELP_OUTPUT)
-        Usage: qq [TOOLS] [GLOBAL_OPTIONS] [TOOL_OPTIONS]
-            -h, --help                       Prints this help
-            -E, --executor EXECUTOR          Which executor to use
-            -A, --annotate ANNOTATOR         Annotate with this annotator
-            -G, --annotate-github-stdout     Annotate with GitHub Workflow commands
-            -a, --all-files [tool]           Use the tool(s) on all files
-            -c, --changed-files [tool]       Use the tool(s) only on changed files
-            -B, --comparison-branch BRANCH   Specify the branch to compare against
-            -f, --filter-messages [tool]     Filter messages from tool(s) based on changed lines
-            -u, --unfiltered [tool]          Don't filter messages from tool(s)
-      HELP_OUTPUT
-    end
-  end
+    describe "parsed tool names" do
+      subject(:tool_names) { parsed.tools }
 
-  describe "executor options" do
-    subject(:executor_option) { parsed[1][:executor] }
-    expect_options("(none)", [], global: {executor: :concurrent})
-    expect_options("--executor concurrent", ["--executor", "concurrent"], global: {executor: :concurrent})
-    expect_options("--executor serial", ["--executor", "serial"], global: {executor: :serial})
-    expect_options("-Econcurrent", ["-Econcurrent"], global: {executor: :concurrent})
-    expect_options("-Eserial", ["-Eserial"], global: {executor: :serial})
-    expect_usage_error("--executor fooba", ["--executor", "fooba"], /Unrecognized executor/)
-    expect_usage_error("-Efooba", ["-Efooba"], /Unrecognized executor/)
-  end
+      context "when none are given" do
+        let(:args) { ["-a", "-u", "rspec", "-c", "standardrb"] }
+        it { is_expected.to be_empty }
+      end
 
-  describe "annotation options" do
-    subject(:annotation_option) { parsed[1][:annotator] }
-    expect_options("--annotate github_stdout", ["--annotate", "github_stdout"], global: {annotator: :github_stdout})
-    expect_options("-Agithub_stdout", ["-Agithub_stdout"], global: {annotator: :github_stdout})
-    expect_options("--annotate-github-stdout", ["--annotate-github-stdout"], global: {annotator: :github_stdout})
-    expect_options("-G", ["-G"], global: {annotator: :github_stdout})
-    expect_usage_error("--annotate foo_bar", ["--annotate", "foo_bar"], /Unrecognized annotator/i)
-    expect_usage_error("-Afoo_bar", ["-Afoo_bar"], /Unrecognized annotator/i)
-  end
+      context "when a few are supplied" do
+        let(:args) { ["rspec", "standardrb", "-a", "-u", "rspec", "-c", "standardrb"] }
+        it { is_expected.to eq(["rspec", "standardrb"]) }
+      end
 
-  describe "file targeting options" do
-    def self.expect_all_files(desc, arguments, globally:, **tools)
-      tool_args = tools.each_pair.map { |tool, value| [tool, {all_files: value}] }.to_h
-      expect_options(desc, arguments, global: {all_files: globally}, **tool_args)
+      context "when they are mixed in with the flags for some reason" do
+        let(:args) { ["-a", "-u", "rspec", "rspec", "-c", "standardrb", "standardrb"] }
+        it { is_expected.to eq(["rspec", "standardrb"]) }
+      end
     end
 
-    expect_all_files("nothing", [], globally: nil, standardrb: nil, rubocop: nil, rspec: nil)
-    expect_all_files("--all-files", ["--all-files"], globally: true)
-    expect_all_files("-a", ["-a"], globally: true)
-    expect_all_files("--changed-files", ["--changed-files"], globally: false)
-    expect_all_files("-c", ["-c"], globally: false)
-    expect_all_files("--all-files standardrb", ["--all-files", "standardrb"], globally: nil, standardrb: true, rubocop: nil, rspec: nil)
-    expect_all_files("-a -crspec", ["-a", "-crspec"], globally: true, rspec: false, standardrb: nil, rubocop: nil)
-    expect_all_files("-arspec -crubocop", ["-arspec", "-crubocop"], globally: nil, rspec: true, rubocop: false, standardrb: nil)
-
-    expect_usage_error("--all-files fooba", ["--all-files", "fooba"], /Unrecognized tool/)
-    expect_usage_error("-afooba", ["-afooba"], /Unrecognized tool/)
-    expect_usage_error("--changed-files fooba", ["--changed-files", "fooba"], /Unrecognized tool/)
-    expect_usage_error("-cfooba", ["-cfooba"], /Unrecognized tool/)
-
-    expect_options("nothing", [], global: {comparison_branch: nil})
-    expect_options("--comparison-branch trunk", ["--comparison-branch", "trunk"], global: {comparison_branch: "trunk"})
-    expect_options("-Btrunk", ["-Btrunk"], global: {comparison_branch: "trunk"})
-  end
-
-  describe "filtering options" do
-    def self.expect_filter_messages(desc, arguments, globally:, **tools)
-      tool_args = tools.each_pair.map { |tool, value| [tool, {filter_messages: value}] }.to_h
-      expect_options(desc, arguments, global: {filter_messages: globally}, **tool_args)
+    describe "executor options" do
+      subject(:executor_option) { parsed[1][:executor] }
+      expect_options("(none)", [], global: {executor: nil})
+      expect_options("--executor concurrent", ["--executor", "concurrent"], global: {executor: :concurrent})
+      expect_options("--executor serial", ["--executor", "serial"], global: {executor: :serial})
+      expect_options("-Econcurrent", ["-Econcurrent"], global: {executor: :concurrent})
+      expect_options("-Eserial", ["-Eserial"], global: {executor: :serial})
+      expect_usage_error("--executor fooba", ["--executor", "fooba"], /Unrecognized executor/)
+      expect_usage_error("-Efooba", ["-Efooba"], /Unrecognized executor/)
     end
 
-    expect_filter_messages("nothing", [], globally: nil, standardrb: nil, rubocop: nil, rspec: nil)
-    expect_filter_messages("--filter-messages", ["--filter-messages"], globally: true)
-    expect_filter_messages("-f", ["-f"], globally: true)
-    expect_filter_messages("--unfiltered", ["--unfiltered"], globally: false)
-    expect_filter_messages("-u", ["-u"], globally: false)
-    expect_filter_messages("--filter-messages standardrb", ["--filter-messages", "standardrb"], globally: nil, standardrb: true, rubocop: nil, rspec: nil)
-    expect_filter_messages("-f -urspec", ["-f", "-urspec"], globally: true, rspec: false, standardrb: nil, rubocop: nil)
-    expect_filter_messages("-frspec -urubocop", ["-frspec", "-urubocop"], globally: nil, rspec: true, rubocop: false, standardrb: nil)
+    describe "annotation options" do
+      subject(:annotation_option) { parsed[1][:annotator] }
+      expect_options("--annotate github_stdout", ["--annotate", "github_stdout"], global: {annotator: :github_stdout})
+      expect_options("-Agithub_stdout", ["-Agithub_stdout"], global: {annotator: :github_stdout})
+      expect_options("--annotate-github-stdout", ["--annotate-github-stdout"], global: {annotator: :github_stdout})
+      expect_options("-G", ["-G"], global: {annotator: :github_stdout})
+      expect_usage_error("--annotate foo_bar", ["--annotate", "foo_bar"], /Unrecognized annotator/i)
+      expect_usage_error("-Afoo_bar", ["-Afoo_bar"], /Unrecognized annotator/i)
+    end
 
-    expect_usage_error("--filter-messages fooba", ["--filter-messages", "fooba"], /Unrecognized tool/)
-    expect_usage_error("-ffooba", ["-ffooba"], /Unrecognized tool/)
-    expect_usage_error("--unfiltered fooba", ["--unfiltered", "fooba"], /Unrecognized tool/)
-    expect_usage_error("-ufooba", ["-ufooba"], /Unrecognized tool/)
+    describe "file targeting options" do
+      def self.expect_all_files(desc, arguments, globally:, **tools)
+        tool_args = tools.each_pair.map { |tool, value| [tool, {all_files: value}] }.to_h
+        expect_options(desc, arguments, global: {all_files: globally}, **tool_args)
+      end
+
+      expect_all_files("nothing", [], globally: nil, standardrb: nil, rubocop: nil, rspec: nil)
+      expect_all_files("--all-files", ["--all-files"], globally: true)
+      expect_all_files("-a", ["-a"], globally: true)
+      expect_all_files("--changed-files", ["--changed-files"], globally: false)
+      expect_all_files("-c", ["-c"], globally: false)
+      expect_all_files("--all-files standardrb", ["--all-files", "standardrb"], globally: nil, standardrb: true, rubocop: nil, rspec: nil)
+      expect_all_files("-a -crspec", ["-a", "-crspec"], globally: true, rspec: false, standardrb: nil, rubocop: nil)
+      expect_all_files("-arspec -crubocop", ["-arspec", "-crubocop"], globally: nil, rspec: true, rubocop: false, standardrb: nil)
+
+      expect_usage_error("--all-files fooba", ["--all-files", "fooba"], /Unrecognized tool/)
+      expect_usage_error("-afooba", ["-afooba"], /Unrecognized tool/)
+      expect_usage_error("--changed-files fooba", ["--changed-files", "fooba"], /Unrecognized tool/)
+      expect_usage_error("-cfooba", ["-cfooba"], /Unrecognized tool/)
+
+      expect_options("nothing", [], global: {comparison_branch: nil})
+      expect_options("--comparison-branch trunk", ["--comparison-branch", "trunk"], global: {comparison_branch: "trunk"})
+      expect_options("-Btrunk", ["-Btrunk"], global: {comparison_branch: "trunk"})
+    end
+
+    describe "filtering options" do
+      def self.expect_filter_messages(desc, arguments, globally:, **tools)
+        tool_args = tools.each_pair.map { |tool, value| [tool, {filter_messages: value}] }.to_h
+        expect_options(desc, arguments, global: {filter_messages: globally}, **tool_args)
+      end
+
+      expect_filter_messages("nothing", [], globally: nil, standardrb: nil, rubocop: nil, rspec: nil)
+      expect_filter_messages("--filter-messages", ["--filter-messages"], globally: true)
+      expect_filter_messages("-f", ["-f"], globally: true)
+      expect_filter_messages("--unfiltered", ["--unfiltered"], globally: false)
+      expect_filter_messages("-u", ["-u"], globally: false)
+      expect_filter_messages("--filter-messages standardrb", ["--filter-messages", "standardrb"], globally: nil, standardrb: true, rubocop: nil, rspec: nil)
+      expect_filter_messages("-f -urspec", ["-f", "-urspec"], globally: true, rspec: false, standardrb: nil, rubocop: nil)
+      expect_filter_messages("-frspec -urubocop", ["-frspec", "-urubocop"], globally: nil, rspec: true, rubocop: false, standardrb: nil)
+
+      expect_usage_error("--filter-messages fooba", ["--filter-messages", "fooba"], /Unrecognized tool/)
+      expect_usage_error("-ffooba", ["-ffooba"], /Unrecognized tool/)
+      expect_usage_error("--unfiltered fooba", ["--unfiltered", "fooba"], /Unrecognized tool/)
+      expect_usage_error("-ufooba", ["-ufooba"], /Unrecognized tool/)
+    end
   end
 end

--- a/spec/quiet_quality/cli/entrypoint_spec.rb
+++ b/spec/quiet_quality/cli/entrypoint_spec.rb
@@ -90,6 +90,22 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
         end
       end
     end
+
+    context "when asked for --help" do
+      let(:argv) { ["--help"] }
+
+      it { is_expected.to be_successful }
+
+      it "does not run the executor" do
+        execute
+        expect(executor).not_to have_received(:execute!)
+      end
+
+      it "prints the help information to the error stream" do
+        execute
+        expect(error_stream).to have_received(:puts).with(a_string_matching(/Usage:/))
+      end
+    end
   end
 
   describe "#successful?" do
@@ -102,6 +118,11 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
 
     context "when the executor reports no failure" do
       let(:any_failure?) { false }
+      it { is_expected.to be_truthy }
+    end
+
+    context "when asked for --help" do
+      let(:argv) { ["--help"] }
       it { is_expected.to be_truthy }
     end
   end

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe QuietQuality::Config::Builder do
   let(:tool_names) { [:rspec, :rubocop, :standardrb] }
   let(:global_options) { {} }
   let(:tool_options) { {} }
-  subject(:builder) { described_class.new(tool_names: tool_names, global_options: global_options, tool_options: tool_options) }
+  let(:parsed_cli) { parsed_options(tools: tool_names, global_options: global_options, tool_options: tool_options) }
+  subject(:builder) { described_class.new(parsed_cli_options: parsed_cli) }
 
   describe "#options" do
     subject(:options) { builder.options }

--- a/spec/quiet_quality/config/parsed_options_spec.rb
+++ b/spec/quiet_quality/config/parsed_options_spec.rb
@@ -3,8 +3,6 @@ RSpec.describe QuietQuality::Config::ParsedOptions do
 
   it { is_expected.to respond_to(:tools) }
   it { is_expected.to respond_to(:tools=) }
-  it { is_expected.to respond_to(:help_text) }
-  it { is_expected.to respond_to(:help_text=) }
 
   describe "#helping?" do
     subject(:helping?) { parsed_options.helping? }

--- a/spec/quiet_quality/config/parsed_options_spec.rb
+++ b/spec/quiet_quality/config/parsed_options_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe QuietQuality::Config::ParsedOptions do
+  subject(:parsed_options) { described_class.new }
+
+  it { is_expected.to respond_to(:tools) }
+  it { is_expected.to respond_to(:tools=) }
+  it { is_expected.to respond_to(:help_text) }
+  it { is_expected.to respond_to(:help_text=) }
+
+  describe "#helping?" do
+    subject(:helping?) { parsed_options.helping? }
+
+    context "when helping is not set" do
+      it { is_expected.to be_falsey }
+    end
+
+    context "when helping is set" do
+      before { parsed_options.helping = true }
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe "a global option" do
+    it "is nil until set" do
+      expect(parsed_options.global_option(:foo)).to be_nil
+      expect(parsed_options.global_option(:bar)).to be_nil
+    end
+
+    it "can be set and then retrieved" do
+      expect { parsed_options.set_global_option(:foo, :bar) }
+        .to change { parsed_options.global_option(:foo) }
+        .from(nil).to(:bar)
+    end
+
+    it "can be set multiple times" do
+      parsed_options.set_global_option(:foo, :bar)
+      parsed_options.set_global_option(:foo, :baz)
+      expect(parsed_options.global_option(:foo)).to eq(:baz)
+    end
+
+    it "can be set and retrieved with strings or symbols" do
+      parsed_options.set_global_option("foo1", "bar1")
+      expect(parsed_options.global_option(:foo1)).to eq("bar1")
+
+      parsed_options.set_global_option(:foo2, "bar2")
+      expect(parsed_options.global_option("foo2")).to eq("bar2")
+    end
+
+    it "can store and retrieve falsey values" do
+      parsed_options.set_global_option(:foo, false)
+      expect(parsed_options.global_option(:foo)).to eq(false)
+    end
+  end
+
+  describe "a tool option" do
+    it "is nil until set" do
+      expect(parsed_options.tool_option(:spade, :foo)).to be_nil
+      expect(parsed_options.tool_option(:hammer, :bar)).to be_nil
+    end
+
+    it "can be set and then retrieved" do
+      parsed_options.set_tool_option(:spade, :foo, true)
+      expect(parsed_options.tool_option(:spade, :foo)).to eq(true)
+    end
+
+    it "can be set multiple times" do
+      parsed_options.set_tool_option(:spade, :foo, :bar)
+      parsed_options.set_tool_option(:spade, :foo, :baz)
+      expect(parsed_options.tool_option(:spade, :foo)).to eq(:baz)
+    end
+
+    it "can be set with strings and then retrieved with symbols" do
+      parsed_options.set_tool_option("spade", "foo1", "bar1")
+      expect(parsed_options.tool_option(:spade, :foo1)).to eq("bar1")
+
+      parsed_options.set_tool_option(:spade, :foo1, "bar2")
+      expect(parsed_options.tool_option("spade", "foo1")).to eq("bar2")
+    end
+
+    it "can store and retrieve falsey values" do
+      parsed_options.set_tool_option(:spade, :foo, false)
+      expect(parsed_options.tool_option(:spade, :foo)).to eq(false)
+    end
+
+    it "can be set differently for different tools" do
+      parsed_options.set_tool_option(:spade, :foo, true)
+      parsed_options.set_tool_option(:hammer, :foo, false)
+      expect(parsed_options.tool_option(:spade, :foo)).to eq(true)
+      expect(parsed_options.tool_option(:hammer, :foo)).to eq(false)
+    end
+
+    it "is not affected by a matching global option" do
+      parsed_options.set_tool_option(:spade, :foo, true)
+      parsed_options.set_global_option(:foo, false)
+      expect(parsed_options.tool_option(:spade, :foo)).to eq(true)
+    end
+  end
+end

--- a/spec/support/option_setup.rb
+++ b/spec/support/option_setup.rb
@@ -2,6 +2,28 @@ module OptionSetup
   def tool_options(tool, **args)
     QuietQuality::Config::ToolOptions.new(tool, **args)
   end
+
+  def parsed_options(global_options: {}, tool_options: {}, **attrs)
+    po = QuietQuality::Config::ParsedOptions.new
+    po.tools = attrs.fetch(:tools, [])
+    po.help_text = attrs.fetch(:help_text, "fake help text")
+    po.helping = attrs.fetch(:helping, false)
+    set_global_options(po, global_options)
+    set_tool_options(po, tool_options)
+    po
+  end
+
+  private
+
+  def set_global_options(po, global_options)
+    global_options.each_pair { |name, value| po.set_global_option(name, value) }
+  end
+
+  def set_tool_options(po, tool_options)
+    tool_options.each_pair do |tool, specifics|
+      specifics.each_pair { |name, value| po.set_tool_option(tool, name, value) }
+    end
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/option_setup.rb
+++ b/spec/support/option_setup.rb
@@ -6,7 +6,6 @@ module OptionSetup
   def parsed_options(global_options: {}, tool_options: {}, **attrs)
     po = QuietQuality::Config::ParsedOptions.new
     po.tools = attrs.fetch(:tools, [])
-    po.help_text = attrs.fetch(:help_text, "fake help text")
     po.helping = attrs.fetch(:helping, false)
     set_global_options(po, global_options)
     set_tool_options(po, tool_options)


### PR DESCRIPTION
## Purpose
Instead of exposing data directly from the ArgParser, factor out a ParsedOptions class that holds the _results_ of parsing the cli arguments (as well as the help-text). Now the ArgParser simply produces one of these and the OptionsBuilder receives one.

Additionally, fix up the handling of the `--help` flag (which was simply broken before). Instead of exposing a pseudo 'option' from the parser indicating that the script should exit without executing, expose `helping?` on the ParsedOptions, and let the Entrypoint properly handle that condition (and test it).

### Next Steps
The primary goal of this change is to set us up for the next slice, in which the OptionsBuilder is split in half, and the "updating" portion of it extracted. That's because the implementation of config parsing requires us to first apply one set of parsed options (from the config file) and _then_ apply another set in exactly the same way (from the cli arg-parser).