### PR TITLE
Add config-file parsing

### DIFF
--- a/.quiet_quality.yml
+++ b/.quiet_quality.yml
@@ -1,0 +1,6 @@
+---
+default_tools: ["standardrb", "rubocop", "rspec"]
+executor: concurrent
+comparison_branch: main
+changed_files: false
+filter_messages: false

--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -12,7 +12,7 @@ module QuietQuality
       def parsed_options
         unless @parsed
           parser.parse!(@args)
-          @parsed_options.tools = validated_tool_names(@args.dup)
+          @parsed_options.tools = validated_tool_names(@args.dup).map(&:to_sym)
           @parsed = true
         end
         @parsed_options

--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -60,6 +60,7 @@ module QuietQuality
         @_parser ||= ::OptionParser.new do |parser|
           setup_banner(parser)
           setup_help_output(parser)
+          setup_config_options(parser)
           setup_executor_options(parser)
           setup_annotation_options(parser)
           setup_file_target_options(parser)
@@ -74,6 +75,12 @@ module QuietQuality
       def setup_help_output(parser)
         parser.on("-h", "--help", "Prints this help") do
           @parsed_options.helping = true
+        end
+      end
+
+      def setup_config_options(parser)
+        parser.on("-C", "--config PATH", "Load a config file from this path") do |path|
+          set_global_option(:config_path, path)
         end
       end
 

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -1,0 +1,134 @@
+module QuietQuality
+  module Config
+    class Parser
+      InvalidConfig = Class.new(Config::Error)
+
+      def initialize(path)
+        @path = path
+      end
+
+      def parsed_options
+        @_parsed_options ||= ParsedOptions.new.tap do |opts|
+          store_default_tools(opts)
+          store_global_options(opts)
+          store_tool_options(opts)
+        end
+      end
+
+      private
+
+      attr_reader :path
+
+      def text
+        @_text ||= File.read(path)
+      end
+
+      def data
+        @_data ||= YAML.safe_load(text, symbolize_names: true)
+      end
+
+      def store_default_tools(opts)
+        tool_names = data.fetch(:default_tools, [])
+        invalid!("default_tools must be an array") unless tool_names.is_a?(Array)
+        tool_names.each do |name|
+          invalid!("each default tool must be a string") unless name.is_a?(String)
+          invalid!("unrecognized tool name '#{name}'") unless valid_tool?(name)
+        end
+        opts.tools = tool_names.map(&:to_sym)
+      end
+
+      def store_global_options(opts)
+        read_global_option(opts, :executor, as: :symbol, validate_from: Executors::AVAILABLE)
+        read_global_option(opts, :annotator, as: :symbol, validate_from: Annotators::ANNOTATOR_TYPES)
+        read_global_option(opts, :comparison_branch, as: :string)
+        read_global_option(opts, :changed_files, as: :boolean)
+        read_global_option(opts, :filter_messages, as: :boolean)
+      end
+
+      def store_tool_options(opts)
+        Tools::AVAILABLE.keys.each do |tool_name|
+          store_tool_options_for(opts, tool_name)
+        end
+      end
+
+      def store_tool_options_for(opts, tool_name)
+        entries = data.fetch(tool_name, nil)
+        return if entries.nil?
+        read_tool_option(opts, tool_name, :filter_messages, as: :boolean)
+        read_tool_option(opts, tool_name, :changed_files, as: :boolean)
+      end
+
+      def invalid!(message)
+        fail(InvalidConfig, message)
+      end
+
+      def valid_tool?(name)
+        Tools::AVAILABLE.key?(name.to_sym)
+      end
+
+      def valid_boolean?(value)
+        [true, false].include?(value)
+      end
+
+      def read_global_option(opts, name, as:, validate_from: nil)
+        parsed_value = data.fetch(name.to_sym, nil)
+        return if parsed_value.nil?
+
+        validate_value(name, parsed_value, as: as, from: validate_from)
+        coerced_value = coerce_value(parsed_value, as: as)
+        opts.set_global_option(name, coerced_value)
+      end
+
+      def read_tool_option(opts, tool, name, as:)
+        parsed_value = data.dig(tool.to_sym, name.to_sym)
+        return if parsed_value.nil?
+
+        validate_value("#{tool}.#{name}", parsed_value, as: as)
+        coerced_value = coerce_value(parsed_value, as: as)
+        opts.set_tool_option(tool, name, coerced_value)
+      end
+
+      def validate_value(name, value, as:, from: nil)
+        case as
+        when :boolean then validate_boolean(name, value)
+        when :symbol then validate_symbol(name, value, from: from)
+        when :string then validate_string(name, value)
+        else
+          fail ArgumentError, "validate_value does not handle type #{as}"
+        end
+      end
+
+      def validate_boolean(name, value)
+        return if valid_boolean?(value)
+        invalid!("option #{name} must be either true or false")
+      end
+
+      def validate_symbol(name, value, from: nil)
+        unless value.is_a?(String) || value.is_a?(Symbol)
+          invalid!("option #{name} must be a string or symbol")
+        end
+
+        unless from.nil? || from.include?(value.to_sym)
+          allowed_list = from.respond_to?(:keys) ? from.keys : from
+          allowed_string = allowed_list.map(&:to_s).join(", ")
+          invalid!("option #{name} must be one of the allowed values: #{allowed_string}")
+        end
+      end
+
+      def validate_string(name, value)
+        invalid!("option #{name} must be a string") unless value.is_a?(String)
+        invalid!("option #{name} must not be empty") if value.empty?
+      end
+
+      def coerce_value(value, as:)
+        case as
+        when :boolean then !!value
+        when :string then value.to_s
+        when :symbol then value.to_sym
+        else
+          fail ArgumentError, "coerce_value does not handle type #{as}"
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/configs/valid.yml
+++ b/spec/fixtures/configs/valid.yml
@@ -1,0 +1,14 @@
+---
+default_tools: ["standardrb", "rubocop"]
+executor: concurrent
+comparison_branch: master
+changed_files: true
+filter_messages: false
+
+rspec:
+  filter_messages: false
+  changed_files: false
+standardrb:
+  filter_messages: true
+rubocop:
+  changed_files: false

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe QuietQuality::Cli::ArgParser do
       expect(help_text).to eq(<<~HELP_OUTPUT)
         Usage: qq [TOOLS] [GLOBAL_OPTIONS] [TOOL_OPTIONS]
             -h, --help                       Prints this help
+            -C, --config PATH                Load a config file from this path
             -E, --executor EXECUTOR          Which executor to use
             -A, --annotate ANNOTATOR         Annotate with this annotator
             -G, --annotate-github-stdout     Annotate with GitHub Workflow commands
@@ -95,8 +96,13 @@ RSpec.describe QuietQuality::Cli::ArgParser do
       end
     end
 
+    describe "config file options" do
+      expect_options("(none)", [], global: {config_path: nil, skip_config: nil})
+      expect_options("-Cbar.yml", ["-Cbar.yml"], global: {config_path: "bar.yml"})
+      expect_options("--config bar.yml", ["--config", "bar.yml"], global: {config_path: "bar.yml"})
+    end
+
     describe "executor options" do
-      subject(:executor_option) { parsed[1][:executor] }
       expect_options("(none)", [], global: {executor: nil})
       expect_options("--executor concurrent", ["--executor", "concurrent"], global: {executor: :concurrent})
       expect_options("--executor serial", ["--executor", "serial"], global: {executor: :serial})
@@ -107,7 +113,6 @@ RSpec.describe QuietQuality::Cli::ArgParser do
     end
 
     describe "annotation options" do
-      subject(:annotation_option) { parsed[1][:annotator] }
       expect_options("--annotate github_stdout", ["--annotate", "github_stdout"], global: {annotator: :github_stdout})
       expect_options("-Agithub_stdout", ["-Agithub_stdout"], global: {annotator: :github_stdout})
       expect_options("--annotate-github-stdout", ["--annotate-github-stdout"], global: {annotator: :github_stdout})

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -79,12 +79,12 @@ RSpec.describe QuietQuality::Cli::ArgParser do
 
       context "when a few are supplied" do
         let(:args) { ["rspec", "standardrb", "-a", "-u", "rspec", "-c", "standardrb"] }
-        it { is_expected.to eq(["rspec", "standardrb"]) }
+        it { is_expected.to eq([:rspec, :standardrb]) }
       end
 
       context "when they are mixed in with the flags for some reason" do
         let(:args) { ["-a", "-u", "rspec", "rspec", "-c", "standardrb", "standardrb"] }
-        it { is_expected.to eq(["rspec", "standardrb"]) }
+        it { is_expected.to eq([:rspec, :standardrb]) }
       end
 
       context "when invalid tool names are supplied" do

--- a/spec/quiet_quality/config/parser_spec.rb
+++ b/spec/quiet_quality/config/parser_spec.rb
@@ -1,0 +1,128 @@
+RSpec.describe QuietQuality::Config::Parser do
+  subject(:parser) { described_class.new(path) }
+
+  describe "#parsed_options" do
+    subject(:parsed_options) { parser.parsed_options }
+
+    def self.expect_default_tools(*tools)
+      it "has the expected default tools set" do
+        expect(parsed_options.tools).to match_array(tools)
+      end
+    end
+
+    def self.expect_global_options(expected_options)
+      it "has the expected global options set" do
+        expected_options.each_pair do |name, value|
+          expect(parsed_options.global_option(name)).to eq(value)
+        end
+      end
+    end
+
+    def self.expect_tool_options(tool_options)
+      it "has the expected tool options set" do
+        tool_options.each_pair do |tool_name, topts|
+          topts.each_pair do |name, value|
+            expect(parsed_options.tool_option(tool_name, name)).to eq(value)
+          end
+        end
+      end
+    end
+
+    def self.expect_invalid(description, config, matcher)
+      context "with a config that is invalid because of #{description}" do
+        let(:yaml) { config }
+
+        it "raises the expected InvalidConfig" do
+          expect { parsed_options }
+            .to raise_error(QuietQuality::Config::Parser::InvalidConfig, matcher)
+        end
+      end
+    end
+
+    def self.expect_config(description, config, defaults: nil, globals: nil, tools: nil)
+      context "with a config that has #{description}" do
+        let(:yaml) { config }
+        expect_default_tools(*defaults) if defaults
+        expect_global_options(globals) if globals
+        expect_tool_options(tools) if tools
+      end
+    end
+
+    context "with a complex and valid configuration file" do
+      let(:path) { fixture_path("configs", "valid.yml") }
+      it { is_expected.to be_a(QuietQuality::Config::ParsedOptions) }
+      expect_default_tools(:standardrb, :rubocop)
+      expect_global_options(
+        executor: :concurrent,
+        annotator: nil,
+        comparison_branch: "master",
+        changed_files: true,
+        filter_messages: false
+      )
+      expect_tool_options(
+        rspec: {filter_messages: false, changed_files: false},
+        standardrb: {filter_messages: true, changed_files: nil},
+        rubocop: {filter_messages: nil, changed_files: false}
+      )
+    end
+
+    context "with a mocked configuration file" do
+      let(:path) { "/tmp/fake/file.yml" }
+      before { allow(File).to receive(:read).and_call_original }
+      before { allow(File).to receive(:read).with(path).and_return(yaml) }
+
+      context "that is simple but correct" do
+        let(:yaml) { "{changed_files: true}" }
+        it { is_expected.to be_a(QuietQuality::Config::ParsedOptions) }
+        expect_global_options(changed_files: true, executor: nil, annotator: nil)
+      end
+
+      describe "the default_tools parsing" do
+        expect_config "an array of known tools", %({default_tools: ["rspec", "rubocop"]}), defaults: [:rspec, :rubocop]
+        expect_invalid "a non-array default_tools value", %({default_tools: "rspec"}), /must be an array/
+        expect_invalid "a non-string default_tools entry", %({default_tools: ["rspec", 3]}), /must be a string/
+        expect_invalid "an unrecognized default_tools entry", %({default_tools: ["foo"]}), /unrecognized tool/
+      end
+
+      describe "executor parsing" do
+        expect_config "no executor", %({}), globals: {executor: nil}
+        expect_config "a concurrent executor", %({executor: "concurrent"}), globals: {executor: :concurrent}
+        expect_config "a serial executor", %({executor: "serial"}), globals: {executor: :serial}
+        expect_invalid "a fooba executor", %({executor: "fooba"}), /one of the allowed values/
+        expect_invalid "a numeric executor", %({executor: 5}), /string or symbol/
+      end
+
+      describe "annotator parsing" do
+        expect_config "no annotator", %({}), globals: {annotator: nil}
+        expect_config "a github_stdout annotator", %({annotator: "github_stdout"}), globals: {annotator: :github_stdout}
+        expect_invalid "a fooba annotator", %({annotator: "fooba"}), /one of the allowed values/
+        expect_invalid "a numeric annotator", %({annotator: 5}), /string or symbol/
+      end
+
+      describe "comparison_branch parsing" do
+        expect_config "no comparison_branch", %({}), globals: {comparison_branch: nil}
+        expect_config "a comparison_branch", %({comparison_branch: "main"}), globals: {comparison_branch: "main"}
+        expect_invalid "a numeric comparison_branch", %({comparison_branch: 5}), /must be a string/
+        expect_invalid "an empty comparison_branch", %({comparison_branch: ""}), /must not be empty/
+      end
+
+      describe "changed_files parsing" do
+        expect_config "no settings", %({}), globals: {changed_files: nil}, tools: {rspec: {changed_files: nil}}
+        expect_config "a global changed_files", %({changed_files: true}), globals: {changed_files: true}, tools: {rspec: {changed_files: nil}}
+        expect_config "an rspec changed_files", %({rspec: {changed_files: false}}), globals: {changed_files: nil}, tools: {rspec: {changed_files: false}}
+        expect_config "an rspec changed_files", %({rspec: {changed_files: false}}), globals: {changed_files: nil}, tools: {rspec: {changed_files: false}}
+        expect_config "both changed_files", %({changed_files: true, rspec: {changed_files: false}}), globals: {changed_files: true}, tools: {rspec: {changed_files: false}}
+        expect_invalid "a non-boolean changed_files", %({changed_files: "yeah"}), /either true or false/
+      end
+
+      describe "filter_messages parsing" do
+        expect_config "no settings", %({}), globals: {filter_messages: nil}, tools: {rspec: {filter_messages: nil}}
+        expect_config "a global filter_messages", %({filter_messages: true}), globals: {filter_messages: true}, tools: {rspec: {filter_messages: nil}}
+        expect_config "an rspec filter_messages", %({rspec: {filter_messages: false}}), globals: {filter_messages: nil}, tools: {rspec: {filter_messages: false}}
+        expect_config "an rspec filter_messages", %({rspec: {filter_messages: false}}), globals: {filter_messages: nil}, tools: {rspec: {filter_messages: false}}
+        expect_config "both filter_messages", %({filter_messages: true, rspec: {filter_messages: false}}), globals: {filter_messages: true}, tools: {rspec: {filter_messages: false}}
+        expect_invalid "a non-boolean filter_messages", %({filter_messages: "yeah"}), /either true or false/
+      end
+    end
+  end
+end


### PR DESCRIPTION
For now, we only parse a config file if on is _passed on the command line_ (via the `-C/--config` flag), which isn't really that useful.

The basic strategy is that the cli-parsed options are allowed to contain a `config_path`, and if they do, then the Builder will parse that config as well, and (a) use it as a fallback if the cli didn't specify any tool names, and (b) load it onto the final Options _first_, before the cli-parsed options get loaded on. This allows the cli options to override the config-file options - even a global cli option ought to override a tool-specific config-file option.

The tests for these changes were _voluminous_. I did my best -.-

(Issue #13 will stay open until the automatic loading slice is complete, which is when this will become _useful_. That's also when it will start making sense to build support for tools that we wouldn't actually run against QQ itself, I think)