### PR TITLE
Support brakeman

### DIFF
--- a/lib/quiet_quality/tools.rb
+++ b/lib/quiet_quality/tools.rb
@@ -13,6 +13,7 @@ Dir.glob(glob).sort.each { |f| require f }
 module QuietQuality
   module Tools
     AVAILABLE = {
+      brakeman: Brakeman,
       rspec: Rspec,
       rubocop: Rubocop,
       standardrb: Standardrb

--- a/lib/quiet_quality/tools/brakeman.rb
+++ b/lib/quiet_quality/tools/brakeman.rb
@@ -1,0 +1,13 @@
+require_relative "./rubocop"
+
+module QuietQuality
+  module Tools
+    module Brakeman
+      ExecutionError = Class.new(Tools::Error)
+      ParsingError = Class.new(Tools::Error)
+    end
+  end
+end
+
+glob = File.expand_path("../brakeman/*.rb", __FILE__)
+Dir.glob(glob).sort.each { |f| require f }

--- a/lib/quiet_quality/tools/brakeman/parser.rb
+++ b/lib/quiet_quality/tools/brakeman/parser.rb
@@ -1,0 +1,45 @@
+module QuietQuality
+  module Tools
+    module Brakeman
+      class Parser
+        def initialize(text)
+          @text = text
+        end
+
+        def messages
+          return @_messages if defined?(@_messages)
+          check_errors!
+          messages = warnings.map { |w| message_for(w) }
+          @_messages = Messages.new(messages)
+        end
+
+        private
+
+        attr_reader :text
+
+        def data
+          @_data ||= JSON.parse(text, symbolize_names: true)
+        end
+
+        def check_errors!
+          errors = data[:errors]
+          return if errors.nil? || errors.empty?
+          fail(ParsingError, "Found #{errors.length} errors in brakeman output")
+        end
+
+        def warnings
+          data[:warnings] || []
+        end
+
+        def message_for(warning)
+          path = warning.fetch(:file)
+          body = warning.fetch(:message)
+          line = warning.fetch(:line)
+          level = warning.fetch(:confidence, nil)
+          rule = warning.fetch(:warning_type)
+          Message.new(path: path, body: body, start_line: line, level: level, rule: rule)
+        end
+      end
+    end
+  end
+end

--- a/lib/quiet_quality/tools/brakeman/runner.rb
+++ b/lib/quiet_quality/tools/brakeman/runner.rb
@@ -1,0 +1,36 @@
+module QuietQuality
+  module Tools
+    module Brakeman
+      class Runner
+        # These are specified in constants at the top of brakeman.rb:
+        #   https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman.rb#L6-L25
+        KNOWN_EXIT_STATUSES = [3, 4, 5, 6, 7, 8].to_set
+
+        def initialize(changed_files: nil)
+          @changed_files = changed_files
+        end
+
+        def invoke!
+          @_outcome ||= performed_outcome
+        end
+
+        private
+
+        def command
+          ["brakeman", "-f", "json"]
+        end
+
+        def performed_outcome
+          out, err, stat = Open3.capture3(*command)
+          if stat.success?
+            Outcome.new(tool: :brakeman, output: out, logging: err)
+          elsif KNOWN_EXIT_STATUSES.include?(stat.exitstatus)
+            Outcome.new(tool: :brakeman, output: out, logging: err, failure: true)
+          else
+            fail(ExecutionError, "Execution of brakeman failed with #{stat.exitstatus}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/quiet_quality/tools/rspec/runner.rb
+++ b/lib/quiet_quality/tools/rspec/runner.rb
@@ -15,7 +15,7 @@ module QuietQuality
 
         private
 
-        attr_reader :changed_files, :error_stream
+        attr_reader :changed_files
 
         def skip_execution?
           changed_files && relevant_files.empty?

--- a/spec/fixtures/tools/brakeman/errors.json
+++ b/spec/fixtures/tools/brakeman/errors.json
@@ -1,0 +1,33 @@
+{
+  "scan_info": {
+    "app_path": "/Users/emueller/src/blank",
+    "rails_version": "7.0.4.3",
+    "security_warnings": 0,
+    "start_time": "2023-05-20 14:52:11 -0400",
+    "end_time": "2023-05-20 14:52:11 -0400",
+    "duration": 0.081141,
+    "checks_performed": [
+      "BasicAuth",
+      "StripTags",
+      "YAMLParsing"
+    ],
+    "number_of_controllers": 1,
+    "number_of_models": 1,
+    "number_of_templates": 2,
+    "ruby_version": "3.1.4",
+    "brakeman_version": "5.4.1"
+  },
+  "warnings": [
+
+  ],
+  "ignored_warnings": [
+
+  ],
+  "errors": [
+    "Something went wrong",
+    "Something else too"
+  ],
+  "obsolete": [
+
+  ]
+}

--- a/spec/fixtures/tools/brakeman/failures.json
+++ b/spec/fixtures/tools/brakeman/failures.json
@@ -1,0 +1,75 @@
+{
+  "scan_info": {
+    "app_path": "/Users/emueller/src/blank",
+    "rails_version": "7.0.4.3",
+    "security_warnings": 2,
+    "start_time": "2023-05-20 15:13:14 -0400",
+    "end_time": "2023-05-20 15:13:14 -0400",
+    "duration": 0.101801,
+    "checks_performed": [
+      "BasicAuth",
+      "SQL",
+      "YAMLParsing"
+    ],
+    "number_of_controllers": 2,
+    "number_of_models": 1,
+    "number_of_templates": 3,
+    "ruby_version": "3.1.4",
+    "brakeman_version": "5.4.1"
+  },
+  "warnings": [
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "510fe4f52a10a04e00467e55324962beaef9960275f9dceaf5d1d7eb5887b5a2",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/controllers/articles_controller.rb",
+      "line": 3,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ApplicationRecord.connection.execute(params[:sql])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ArticlesController",
+        "method": "index"
+      },
+      "user_input": "params[:sql]",
+      "confidence": "High",
+      "cwe_id": [
+        89
+      ]
+    },
+    {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 25,
+      "fingerprint": "68c72b81eabcdc4242ea87c47c880ebeab73958fb18dd74f035f11131e66748a",
+      "check_name": "Deserialize",
+      "message": "`YAML.load` called with parameter value",
+      "file": "app/controllers/articles_controller.rb",
+      "line": 11,
+      "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+      "code": "YAML.load(params[:yaml])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ArticlesController",
+        "method": "do_the_bad_thing"
+      },
+      "user_input": "params[:yaml]",
+      "confidence": "High",
+      "cwe_id": [
+        502
+      ]
+    }
+  ],
+  "ignored_warnings": [
+
+  ],
+  "errors": [
+
+  ],
+  "obsolete": [
+
+  ]
+}

--- a/spec/fixtures/tools/brakeman/no-failures.json
+++ b/spec/fixtures/tools/brakeman/no-failures.json
@@ -1,0 +1,32 @@
+{
+  "scan_info": {
+    "app_path": "/Users/emueller/src/blank",
+    "rails_version": "7.0.4.3",
+    "security_warnings": 0,
+    "start_time": "2023-05-20 14:52:11 -0400",
+    "end_time": "2023-05-20 14:52:11 -0400",
+    "duration": 0.081141,
+    "checks_performed": [
+      "BasicAuth",
+      "StripTags",
+      "YAMLParsing"
+    ],
+    "number_of_controllers": 1,
+    "number_of_models": 1,
+    "number_of_templates": 2,
+    "ruby_version": "3.1.4",
+    "brakeman_version": "5.4.1"
+  },
+  "warnings": [
+
+  ],
+  "ignored_warnings": [
+
+  ],
+  "errors": [
+
+  ],
+  "obsolete": [
+
+  ]
+}

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe QuietQuality::Config::Builder do
         let(:tool_names) { [] }
 
         it "exposes all of the tools" do
-          expect(tools.map(&:tool_name)).to contain_exactly(:rspec, :rubocop, :standardrb)
+          expect(tools.map(&:tool_name)).to match_array(QuietQuality::Tools::AVAILABLE.keys)
         end
 
         context "but there are some specified in a config file" do

--- a/spec/quiet_quality/tools/brakeman/parser_spec.rb
+++ b/spec/quiet_quality/tools/brakeman/parser_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe QuietQuality::Tools::Brakeman::Parser do
+  subject(:parser) { described_class.new(text) }
+
+  describe "#messages" do
+    let(:text) { fixture_content("tools", "brakeman", "no-failures.json") }
+    subject(:messages) { parser.messages }
+
+    it "is memoized" do
+      first_messages = parser.messages
+      expect(parser.messages.object_id).to eq(first_messages.object_id)
+    end
+
+    context "when there are no offenses" do
+      let(:text) { fixture_content("tools", "brakeman", "no-failures.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+      it { is_expected.to be_empty }
+    end
+
+    context "when there are some offenses" do
+      let(:text) { fixture_content("tools", "brakeman", "failures.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+      it { is_expected.not_to be_empty }
+
+      it "has the expected offenses in it" do
+        expect(messages.count).to eq(2)
+        expect(messages.map(&:start_line)).to contain_exactly(3, 11)
+      end
+
+      it "properly populates the messages" do
+        m = messages.detect { |msg| msg.start_line == 3 }
+        expect(m.path).to eq("app/controllers/articles_controller.rb")
+        expect(m.body).to eq("Possible SQL injection")
+        expect(m.start_line).to eq(3)
+        expect(m.level).to eq("High")
+        expect(m.rule).to eq("SQL Injection")
+      end
+    end
+
+    context "when there are errors" do
+      let(:text) { fixture_content("tools", "brakeman", "errors.json") }
+
+      it "raises a ParsingError" do
+        expect { messages }.to raise_error(
+          QuietQuality::Tools::Brakeman::ParsingError,
+          /Found 2 errors/
+        )
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/tools/brakeman/runner_spec.rb
+++ b/spec/quiet_quality/tools/brakeman/runner_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe QuietQuality::Tools::Brakeman::Runner do
+  let(:changed_files) { nil }
+  subject(:runner) { described_class.new }
+
+  let(:out) { "fake output" }
+  let(:err) { "fake error" }
+  let(:stat) { instance_double(Process::Status, success?: true, exitstatus: 0) }
+  before { allow(Open3).to receive(:capture3).and_return([out, err, stat]) }
+
+  describe "#invoke!" do
+    subject(:invoke!) { runner.invoke! }
+
+    context "when the brakeman command fails" do
+      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
+
+      it "raises a Brakeman::ExecutionError" do
+        expect { invoke! }.to raise_error(QuietQuality::Tools::Brakeman::ExecutionError)
+      end
+    end
+
+    context "when the brakeman command finds warnings" do
+      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 3) }
+      it { is_expected.to eq(build_failure(:brakeman, "fake output", "fake error")) }
+
+      it "calls brakeman correctly" do
+        invoke!
+        expect(Open3).to have_received(:capture3).with("brakeman", "-f", "json")
+      end
+    end
+
+    context "when the brakeman command finds no problems" do
+      let(:stat) { instance_double(Process::Status, success?: true, exitstatus: 0) }
+      it { is_expected.to eq(build_success(:brakeman, "fake output", "fake error")) }
+
+      it "calls brakeman correctly" do
+        invoke!
+        expect(Open3).to have_received(:capture3).with("brakeman", "-f", "json")
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/tools/rspec/parser_spec.rb
+++ b/spec/quiet_quality/tools/rspec/parser_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe QuietQuality::Tools::Rspec::Parser do
 
       it "properly populates the message when no exception is present" do
         m = messages.detect { |msg| msg.start_line == 73 }
-        expect(m.path)
         expect(m.path).to eq("spec/quiet_quality/tools/standardrb/runner_spec.rb")
         expect(m.start_line).to eq(73)
         expect(m.rule).to eq("Failed Example")


### PR DESCRIPTION
Support the `brakeman` tool, with a runner and parser. Note that there's not really a way to run brakeman against only a portion of a project, and also it only runs against rails projects.. which means that it's not useful to run against `quiet_quality` itself, for example.

Resolves #49 