### PR TITLE
Support `haml_lint`

### DIFF
--- a/lib/quiet_quality/tools.rb
+++ b/lib/quiet_quality/tools.rb
@@ -14,6 +14,7 @@ module QuietQuality
   module Tools
     AVAILABLE = {
       brakeman: Brakeman,
+      haml_lint: HamlLint,
       rspec: Rspec,
       rubocop: Rubocop,
       standardrb: Standardrb

--- a/lib/quiet_quality/tools/haml_lint.rb
+++ b/lib/quiet_quality/tools/haml_lint.rb
@@ -1,0 +1,11 @@
+module QuietQuality
+  module Tools
+    module HamlLint
+      ExecutionError = Class.new(Tools::Error)
+      ParsingError = Class.new(Tools::Error)
+    end
+  end
+end
+
+glob = File.expand_path("../haml_lint/*.rb", __FILE__)
+Dir.glob(glob).sort.each { |f| require f }

--- a/lib/quiet_quality/tools/haml_lint/parser.rb
+++ b/lib/quiet_quality/tools/haml_lint/parser.rb
@@ -1,0 +1,45 @@
+module QuietQuality
+  module Tools
+    module HamlLint
+      class Parser
+        def initialize(text)
+          @text = text
+        end
+
+        def messages
+          return @_messages if defined?(@_messages)
+          messages = content
+            .fetch(:files)
+            .map { |f| messages_for_file(f) }
+            .flatten
+          @_messages = Messages.new(messages)
+        end
+
+        private
+
+        attr_reader :text
+
+        def content
+          @_content ||= JSON.parse(text, symbolize_names: true)
+        end
+
+        def messages_for_file(file_details)
+          path = file_details.fetch(:path)
+          file_details.fetch(:offenses).map do |offense|
+            message_for_offense(path, offense)
+          end
+        end
+
+        def message_for_offense(path, offense)
+          Message.new(
+            path: path,
+            body: offense.fetch(:message),
+            start_line: offense.dig(:location, :line),
+            level: offense.fetch(:severity, nil),
+            rule: offense.fetch(:linter_name, nil)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/quiet_quality/tools/haml_lint/runner.rb
+++ b/lib/quiet_quality/tools/haml_lint/runner.rb
@@ -1,0 +1,63 @@
+module QuietQuality
+  module Tools
+    module HamlLint
+      class Runner
+        MAX_FILES = 100
+        NO_FILES_OUTPUT = %({"files": []})
+
+        # haml-lint uses the `sysexits` gem, and exits with Sysexits::EX_DATAERR for the
+        # failures case here in lib/haml_lint/cli.rb. That's mapped to status 65 - other
+        # statuses have other failure meanings, which we don't want to interpret as "problems
+        # encountered"
+        FAILURE_STATUS = 65
+
+        def initialize(changed_files: nil)
+          @changed_files = changed_files
+        end
+
+        def invoke!
+          @_outcome ||= skip_execution? ? skipped_outcome : performed_outcome
+        end
+
+        private
+
+        attr_reader :changed_files
+
+        def skip_execution?
+          changed_files && relevant_files.empty?
+        end
+
+        def relevant_files
+          return nil if changed_files.nil?
+          changed_files.paths.select { |path| path.end_with?(".haml") }
+        end
+
+        def target_files
+          return [] if changed_files.nil?
+          return [] if relevant_files.length > MAX_FILES
+          relevant_files
+        end
+
+        def command
+          return nil if skip_execution?
+          ["haml-lint", "--reporter", "json"] + target_files.sort
+        end
+
+        def skipped_outcome
+          Outcome.new(tool: :haml_lint, output: NO_FILES_OUTPUT)
+        end
+
+        def performed_outcome
+          out, err, stat = Open3.capture3(*command)
+          if stat.success?
+            Outcome.new(tool: :haml_lint, output: out, logging: err)
+          elsif stat.exitstatus == FAILURE_STATUS
+            Outcome.new(tool: :haml_lint, output: out, logging: err, failure: true)
+          else
+            fail(ExecutionError, "Execution of haml-lint failed with #{stat.exitstatus}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/tools/haml_lint/failures.json
+++ b/spec/fixtures/tools/haml_lint/failures.json
@@ -1,0 +1,44 @@
+{
+  "metadata": {
+    "haml_lint_version": "0.45.0",
+    "ruby_engine": "ruby",
+    "ruby_patchlevel": "20",
+    "ruby_platform": "arm64-darwin21"
+  },
+  "files": [
+    {
+      "path": "tmp/good.haml",
+      "offenses": [
+        {
+          "severity": "warning",
+          "message": "`%div.foo` can be written as `.foo` since `%div` is implicit",
+          "location": {
+            "line": 1
+          },
+          "linter_name": "ImplicitDiv"
+        },
+        {
+          "severity": "warning",
+          "message": "Hash attribute should start with one space after the opening brace",
+          "location": {
+            "line": 3
+          },
+          "linter_name": "SpaceInsideHashAttributes"
+        },
+        {
+          "severity": "warning",
+          "message": "Hash attribute should end with one space before the closing brace or be on its own line",
+          "location": {
+            "line": 3
+          },
+          "linter_name": "SpaceInsideHashAttributes"
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "offense_count": 3,
+    "target_file_count": 1,
+    "inspected_file_count": 1
+  }
+}

--- a/spec/fixtures/tools/haml_lint/no-failures.json
+++ b/spec/fixtures/tools/haml_lint/no-failures.json
@@ -1,0 +1,16 @@
+{
+  "metadata": {
+    "haml_lint_version": "0.45.0",
+    "ruby_engine": "ruby",
+    "ruby_patchlevel": "20",
+    "ruby_platform": "arm64-darwin21"
+  },
+  "files": [
+
+  ],
+  "summary": {
+    "offense_count": 0,
+    "target_file_count": 0,
+    "inspected_file_count": 1
+  }
+}

--- a/spec/quiet_quality/tools/haml_lint/parser_spec.rb
+++ b/spec/quiet_quality/tools/haml_lint/parser_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe QuietQuality::Tools::HamlLint::Parser do
+  subject(:parser) { described_class.new(text) }
+
+  describe "#messages" do
+    let(:text) { fixture_content("tools", "haml_lint", "no-failures.json") }
+    subject(:messages) { parser.messages }
+
+    it "is memoized" do
+      first_messages = parser.messages
+      expect(parser.messages.object_id).to eq(first_messages.object_id)
+    end
+
+    context "when there are no offenses" do
+      let(:text) { fixture_content("tools", "haml_lint", "no-failures.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+      it { is_expected.to be_empty }
+    end
+
+    context "when there are some offenses" do
+      let(:text) { fixture_content("tools", "haml_lint", "failures.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+      it { is_expected.not_to be_empty }
+
+      it "has the expected offenses in it" do
+        expect(messages.count).to eq(3)
+        expect(messages.map(&:start_line)).to contain_exactly(1, 3, 3)
+      end
+
+      it "fully populates the messages" do
+        expect(messages.first.path).to eq("tmp/good.haml")
+        expect(messages.first.body).to eq("`%div.foo` can be written as `.foo` since `%div` is implicit")
+        expect(messages.first.start_line).to eq(1)
+        expect(messages.first.level).to eq("warning")
+        expect(messages.first.rule).to eq("ImplicitDiv")
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/tools/haml_lint/runner_spec.rb
+++ b/spec/quiet_quality/tools/haml_lint/runner_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe QuietQuality::Tools::HamlLint::Runner do
+  let(:changed_files) { nil }
+  subject(:runner) { described_class.new(changed_files: changed_files) }
+
+  let(:exitstatus) { 0 }
+  before { stub_capture3(status: exitstatus) }
+
+  describe "#invoke!" do
+    subject(:invoke!) { runner.invoke! }
+
+    context "when haml-lint fails" do
+      let(:exitstatus) { 3 }
+
+      it "raises a HamlLint::ExecutionError" do
+        expect { invoke! }.to raise_error(QuietQuality::Tools::HamlLint::ExecutionError)
+      end
+    end
+
+    context "when there are linter rules broken" do
+      let(:exitstatus) { 65 }
+      it { is_expected.to eq(build_failure(:haml_lint, "fake output", "fake error")) }
+
+      it "calls haml-lint with no targets" do
+        invoke!
+        expect(Open3).to have_received(:capture3).with("haml-lint", "--reporter", "json")
+      end
+    end
+
+    context "when changed_files is nil" do
+      let(:changed_files) { nil }
+      it { is_expected.to eq(build_success(:haml_lint, "fake output", "fake error")) }
+
+      it "calls haml-lint with no targets" do
+        invoke!
+        expect(Open3).to have_received(:capture3).with("haml-lint", "--reporter", "json")
+      end
+    end
+
+    context "when changed_files is empty" do
+      let(:changed_files) { empty_changed_files }
+      it { is_expected.to eq(build_success(:haml_lint, described_class::NO_FILES_OUTPUT)) }
+
+      it "does not call haml-lint" do
+        expect(Open3).not_to have_received(:capture3)
+      end
+    end
+
+    context "when changed_files is full" do
+      context "but contains no haml files" do
+        let(:changed_files) { generate_changed_files({"foo_spec.ts" => :all, "bar.rb" => [1, 2], "baz_spec.rb.bak" => [5]}) }
+        it { is_expected.to eq(build_success(:haml_lint, described_class::NO_FILES_OUTPUT)) }
+
+        it "does not call haml-lint" do
+          expect(Open3).not_to have_received(:capture3)
+        end
+      end
+
+      context "and contains some haml files" do
+        let(:changed_paths) { ["foo.html", "bar.haml.erb", "baz.html.haml", "bam.haml"] }
+        let(:changed_files) { generate_changed_files(changed_paths.map { |p| [p, :all] }.to_h) }
+        it { is_expected.to eq(build_success(:haml_lint, "fake output", "fake error")) }
+
+        it "calls haml-lint with the correct targets" do
+          invoke!
+          expect(Open3)
+            .to have_received(:capture3)
+            .with("haml-lint", "--reporter", "json", "bam.haml", "baz.html.haml")
+        end
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/tools/rspec/runner_spec.rb
+++ b/spec/quiet_quality/tools/rspec/runner_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
         let(:changed_files) { generate_changed_files(changed_paths.map { |p| [p, :all] }.to_h) }
         it { is_expected.to eq(build_success(:rspec, "fake output", "fake error")) }
 
-        it "calls rspec with no targets" do
+        it "calls rspec with the correct targets" do
           invoke!
           expect(Open3)
             .to have_received(:capture3)

--- a/spec/support/status_setup.rb
+++ b/spec/support/status_setup.rb
@@ -1,0 +1,16 @@
+module StatusSetup
+  def mock_status(status, success: nil)
+    calculated_success = success.nil? ? status == 0 : success
+    instance_double(Process::Status, success?: calculated_success, exitstatus: status)
+  end
+
+  def stub_capture3(output: "fake output", error: "fake error", status: 0)
+    mock_status(status).tap do |stat|
+      allow(Open3).to receive(:capture3).and_return([output, error, stat])
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include StatusSetup
+end


### PR DESCRIPTION
Support [haml-lint](https://github.com/sds/haml-lint) as a tool. There's a lot of code here that's _very_ similar to existing runners and parsers, but I'm current leaning toward repetition over extraction within the tools, hoping to keep their implementations isolated from each other (aside from standardrb/rubocop, since one tool actually _wraps_ the other).

Resolves #51 