### PR TITLE
Calculate changed files for executor

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
@@ -25,4 +27,4 @@ jobs:
         run: bundle install --jobs 4 --retry 3
 
       - name: Run QuietQuality
-        run: bundle exec bin/qq standardrb rubocop rspec --all-files --unfiltered --annotate github_stdout
+        run: bundle exec bin/qq standardrb rubocop rspec --all-files --unfiltered --annotate github_stdout --comparison-branch origin/main

--- a/lib/quiet_quality/cli/entrypoint.rb
+++ b/lib/quiet_quality/cli/entrypoint.rb
@@ -50,8 +50,18 @@ module QuietQuality
         @_options = builder.options
       end
 
+      def changed_files
+        return @_changed_files if defined?(@_changed_files)
+        @_changed_files = VersionControlSystems::Git.new.changed_files(
+          base: options.comparison_branch,
+          sha: "HEAD",
+          include_uncommitted: true,
+          include_untracked: true
+        )
+      end
+
       def executor
-        @_executor ||= options.executor.new(tools: options.tools)
+        @_executor ||= options.executor.new(tools: options.tools, changed_files: changed_files)
       end
 
       def executed

--- a/lib/quiet_quality/version.rb
+++ b/lib/quiet_quality/version.rb
@@ -1,3 +1,3 @@
 module QuietQuality
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/quiet_quality/cli/entrypoint_spec.rb
+++ b/spec/quiet_quality/cli/entrypoint_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
   let!(:executor) { instance_double(QuietQuality::Executors::ConcurrentExecutor, execute!: nil, messages: messages, outcomes: outcomes, any_failure?: any_failure?) }
   before { allow(QuietQuality::Executors::ConcurrentExecutor).to receive(:new).and_return(executor) }
 
+  let(:changed_files) { instance_double(QuietQuality::ChangedFiles) }
+  let(:git) { instance_double(QuietQuality::VersionControlSystems::Git, changed_files: changed_files) }
+  before { allow(QuietQuality::VersionControlSystems::Git).to receive(:new).and_return(git) }
+
   describe "#execute" do
     subject(:execute) { entrypoint.execute }
 


### PR DESCRIPTION
We weren't actually passing changed_files to the executor, so it was never being used.