### PR TITLE
Do not fail if all messages are filtered

### DIFF
--- a/lib/quiet_quality/executors/pipeline.rb
+++ b/lib/quiet_quality/executors/pipeline.rb
@@ -15,7 +15,7 @@ module QuietQuality
       end
 
       def failure?
-        outcome.failure?
+        messages.any?
       end
 
       def messages

--- a/lib/quiet_quality/version.rb
+++ b/lib/quiet_quality/version.rb
@@ -1,3 +1,3 @@
 module QuietQuality
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
When running with `--filter-messages`, the tool should not fail (or describe itself as failed) when the cli command did fail, but all of the messages are about lines that were not changed relative to the comparison branch. So base the determination of `Pipeline#failed?` on wether there are any messages afterward, instead of on the failure of the runner outcome.