### PR TITLE
Print success when pipeline succeeds

### DIFF
--- a/lib/quiet_quality/executors/pipeline.rb
+++ b/lib/quiet_quality/executors/pipeline.rb
@@ -11,11 +11,16 @@ module QuietQuality
       end
 
       def outcome
-        @_outcome ||= runner.invoke!
+        @_outcome ||= Tools::Outcome.new(
+          tool: runner_outcome.tool,
+          output: runner_outcome.output,
+          logging: runner_outcome.logging,
+          failure: messages.any?
+        )
       end
 
       def failure?
-        messages.any?
+        outcome.failure?
       end
 
       def messages
@@ -29,6 +34,10 @@ module QuietQuality
       private
 
       attr_reader :changed_files, :tool_options
+
+      def runner_outcome
+        @_runner_outcome ||= runner.invoke!
+      end
 
       def limit_targets?
         tool_options.limit_targets?
@@ -44,7 +53,7 @@ module QuietQuality
       end
 
       def parser
-        @_parser ||= tool_options.parser_class.new(outcome.output)
+        @_parser ||= tool_options.parser_class.new(runner_outcome.output)
       end
 
       def relevance_filter

--- a/lib/quiet_quality/version.rb
+++ b/lib/quiet_quality/version.rb
@@ -1,3 +1,3 @@
 module QuietQuality
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/spec/quiet_quality/executors/pipeline_spec.rb
+++ b/spec/quiet_quality/executors/pipeline_spec.rb
@@ -29,7 +29,33 @@ RSpec.describe QuietQuality::Executors::Pipeline do
 
   describe "#outcome" do
     subject(:outcome) { pipeline.outcome }
-    it { is_expected.to eq(runner_outcome) }
+
+    shared_examples "it matches the runner outcome, failure status aside" do
+      it "matches the runner outcome, aside from the failure status" do
+        expect(outcome.output).to eq(runner_outcome.output)
+        expect(outcome.logging).to eq(runner_outcome.logging)
+        expect(outcome.tool).to eq(runner_outcome.tool)
+      end
+    end
+
+    context "when there are messages from the tool" do
+      let(:parsed_messages) { QuietQuality::Messages.new(other_messages + [foo_message, bar_message]) }
+
+      include_examples "it matches the runner outcome, failure status aside"
+      it { is_expected.to be_failure }
+
+      context "but they are all filtered" do
+        let(:parsed_messages) { QuietQuality::Messages.new(other_messages) }
+        include_examples "it matches the runner outcome, failure status aside"
+        it { is_expected.not_to be_failure }
+      end
+    end
+
+    context "when there are no messages from the tool" do
+      let(:parsed_messages) { empty_messages }
+      include_examples "it matches the runner outcome, failure status aside"
+      it { is_expected.not_to be_failure }
+    end
   end
 
   describe "#failure?" do


### PR DESCRIPTION
While we fixed the actual _behavior_ when there are messages from the tool and all are filtered out, the logging was still wrong - the pipeline exposes the _tool_ outcome, rather than its own to the Entrypoint, so you'd still see `Failed: brakeman` despite that there were no _relevant_ messages from that tool.

Instead, update the Pipeline to construct a _new_ Outcome object representing its own outcome, based on the outcome of the Runner, but with the failure status updated depending on the presence of unfiltered messages.