### PR TITLE
Add `--version/-V` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,5 +151,6 @@ The same options are all available on the CLI, plus some additional ones - run
 
 * `--help/-H`: See a list of the options
 * `--no-config/-N`: Do _not_ load a config file, even if present.
-* `--config/-C` load the supplied config file (instead of the detected one, if
+* `--config/-C`: load the supplied config file (instead of the detected one, if
   found)
+* `--version/-V`: what version of the gem are you using?

--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -76,6 +76,10 @@ module QuietQuality
         parser.on("-h", "--help", "Prints this help") do
           @parsed_options.helping = true
         end
+
+        parser.on("-V", "--version", "Print the current version of the gem") do
+          @parsed_options.printing_version = true
+        end
       end
 
       def setup_config_options(parser)

--- a/lib/quiet_quality/cli/entrypoint.rb
+++ b/lib/quiet_quality/cli/entrypoint.rb
@@ -10,6 +10,8 @@ module QuietQuality
       def execute
         if helping?
           log_help_text
+        elsif printing_version?
+          log_version_text
         else
           executed
           log_outcomes
@@ -21,7 +23,7 @@ module QuietQuality
       end
 
       def successful?
-        helping? || !executed.any_failure?
+        helping? || printing_version? || !executed.any_failure?
       end
 
       private
@@ -40,8 +42,16 @@ module QuietQuality
         parsed_options.helping?
       end
 
+      def printing_version?
+        parsed_options.printing_version?
+      end
+
       def log_help_text
         error_stream.puts(arg_parser.help_text)
+      end
+
+      def log_version_text
+        error_stream.puts(QuietQuality::VERSION)
       end
 
       def options

--- a/lib/quiet_quality/config/parsed_options.rb
+++ b/lib/quiet_quality/config/parsed_options.rb
@@ -5,14 +5,18 @@ module QuietQuality
         @tools = []
         @tool_options = {}
         @global_options = {}
-        @helping = false
+        @helping = @printing_version = false
       end
 
       attr_accessor :tools
-      attr_writer :helping
+      attr_writer :helping, :printing_version
 
       def helping?
         @helping
+      end
+
+      def printing_version?
+        @printing_version
       end
 
       def set_global_option(name, value)

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe QuietQuality::Cli::ArgParser do
       expect(help_text).to eq(<<~HELP_OUTPUT)
         Usage: qq [TOOLS] [GLOBAL_OPTIONS] [TOOL_OPTIONS]
             -h, --help                       Prints this help
+            -V, --version                    Print the current version of the gem
             -C, --config PATH                Load a config file from this path
             -N, --no-config                  Do not load a config file, even if present
             -E, --executor EXECUTOR          Which executor to use
@@ -67,6 +68,18 @@ RSpec.describe QuietQuality::Cli::ArgParser do
       context "with --help passed" do
         let(:args) { ["-a", "--help"] }
         it { is_expected.to be_helping }
+      end
+    end
+
+    describe "version option" do
+      context "without --version passed" do
+        let(:args) { ["-a"] }
+        it { is_expected.not_to be_printing_version }
+      end
+
+      context "with --version passed" do
+        let(:args) { ["-a", "--version"] }
+        it { is_expected.to be_printing_version }
       end
     end
 

--- a/spec/quiet_quality/cli/entrypoint_spec.rb
+++ b/spec/quiet_quality/cli/entrypoint_spec.rb
@@ -110,6 +110,22 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
         expect(error_stream).to have_received(:puts).with(a_string_matching(/Usage:/))
       end
     end
+
+    context "when asked for --version" do
+      let(:argv) { ["--version"] }
+
+      it { is_expected.to be_successful }
+
+      it "does not run the executor" do
+        execute
+        expect(executor).not_to have_received(:execute!)
+      end
+
+      it "prints the help information to the error stream" do
+        execute
+        expect(error_stream).to have_received(:puts).with(QuietQuality::VERSION)
+      end
+    end
   end
 
   describe "#successful?" do
@@ -127,6 +143,11 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
 
     context "when asked for --help" do
       let(:argv) { ["--help"] }
+      it { is_expected.to be_truthy }
+    end
+
+    context "when asked for --version" do
+      let(:argv) { ["--version"] }
       it { is_expected.to be_truthy }
     end
   end

--- a/spec/quiet_quality/config/parsed_options_spec.rb
+++ b/spec/quiet_quality/config/parsed_options_spec.rb
@@ -17,6 +17,19 @@ RSpec.describe QuietQuality::Config::ParsedOptions do
     end
   end
 
+  describe "#printing_version?" do
+    subject(:printing_version?) { parsed_options.printing_version? }
+
+    context "when printing_version is not set" do
+      it { is_expected.to be_falsey }
+    end
+
+    context "when printing_version is set" do
+      before { parsed_options.printing_version = true }
+      it { is_expected.to be_truthy }
+    end
+  end
+
   describe "a global option" do
     it "is nil until set" do
       expect(parsed_options.global_option(:foo)).to be_nil

--- a/spec/support/option_setup.rb
+++ b/spec/support/option_setup.rb
@@ -7,6 +7,7 @@ module OptionSetup
     po = QuietQuality::Config::ParsedOptions.new
     po.tools = attrs.fetch(:tools, [])
     po.helping = attrs.fetch(:helping, false)
+    po.printing_version = attrs.fetch(:printing_version, false)
     set_global_options(po, global_options)
     set_tool_options(po, tool_options)
     po


### PR DESCRIPTION
Make it easy to tell what version of `quiet_quality` is actually being executed by asking the command itself. Yes, you can figure this out in other ways, but this is an easy thing to ask someone else to paste you the output from, and most tools support it.

```
❯ qq --version
1.0.3
```

Resolves #69 