### PR TITLE
Allow tools to limit their targets via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,22 @@ And then each tool can have an entry, within which `changed_files` and
 `filter_messages` can be specified - the tool-specific settings override the
 global ones.
 
+The tools have one additional setting that is not available at a global level:
+`file_filter`. This is a string that will be turned into a _ruby regex_, and
+used to limit what file paths are passed to the tool. For example, if you are
+working in a rails engine `engines/foo/`, and you touch one of the rspec tests
+there, you would not want `qq` in the root of the repository to run
+`rspec engines/foo/spec/foo/thing_spec.rb` - that probably won't work, as your
+engine will have its own test setup code and Gemfile. This setting is mostly
+intended to be used like this:
+
+```yaml
+rspec:
+  changed_files: true
+  filter_messages: false
+  file_filter: "^spec/"
+```
+
 ### CLI Options
 
 The same options are all available on the CLI, plus some additional ones - run

--- a/lib/quiet_quality/config/builder.rb
+++ b/lib/quiet_quality/config/builder.rb
@@ -109,6 +109,7 @@ module QuietQuality
           options.tools.each do |tool_options|
             update_tool_option(tool_options, :limit_targets)
             update_tool_option(tool_options, :filter_messages)
+            update_tool_option(tool_options, :file_filter)
           end
         end
 

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -57,7 +57,7 @@ module QuietQuality
       def store_tool_options_for(opts, tool_name)
         entries = data.fetch(tool_name, nil)
         return if entries.nil?
-        
+
         read_tool_option(opts, tool_name, :filter_messages, :filter_messages, as: :boolean)
         read_tool_option(opts, tool_name, :unfiltered, :filter_messages, as: :reversed_boolean)
         read_tool_option(opts, tool_name, :changed_files, :changed_files, as: :boolean)

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -56,6 +56,7 @@ module QuietQuality
         return if entries.nil?
         read_tool_option(opts, tool_name, :filter_messages, as: :boolean)
         read_tool_option(opts, tool_name, :changed_files, as: :boolean)
+        read_tool_option(opts, tool_name, :file_filter, as: :string)
       end
 
       def invalid!(message)

--- a/lib/quiet_quality/config/tool_options.rb
+++ b/lib/quiet_quality/config/tool_options.rb
@@ -1,14 +1,15 @@
 module QuietQuality
   module Config
     class ToolOptions
-      def initialize(tool, limit_targets: true, filter_messages: true)
+      def initialize(tool, limit_targets: true, filter_messages: true, file_filter: nil)
         @tool_name = tool.to_sym
         @limit_targets = limit_targets
         @filter_messages = filter_messages
+        @file_filter = file_filter
       end
 
       attr_reader :tool_name
-      attr_writer :limit_targets, :filter_messages
+      attr_writer :limit_targets, :filter_messages, :file_filter
 
       def limit_targets?
         @limit_targets
@@ -28,6 +29,11 @@ module QuietQuality
 
       def parser_class
         tool_namespace::Parser
+      end
+
+      def file_filter
+        return nil if @file_filter.nil?
+        Regexp.new(@file_filter)
       end
     end
   end

--- a/lib/quiet_quality/executors/pipeline.rb
+++ b/lib/quiet_quality/executors/pipeline.rb
@@ -48,8 +48,10 @@ module QuietQuality
       end
 
       def runner
-        @_runner ||= tool_options.runner_class
-          .new(changed_files: limit_targets? ? changed_files : nil)
+        @_runner ||= tool_options.runner_class.new(
+          changed_files: limit_targets? ? changed_files : nil,
+          file_filter: tool_options.file_filter
+        )
       end
 
       def parser

--- a/lib/quiet_quality/tools/brakeman/runner.rb
+++ b/lib/quiet_quality/tools/brakeman/runner.rb
@@ -6,8 +6,12 @@ module QuietQuality
         #   https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman.rb#L6-L25
         KNOWN_EXIT_STATUSES = [3, 4, 5, 6, 7, 8].to_set
 
-        def initialize(changed_files: nil)
+        # brakeman does not support being run against a portion of the project, so neither
+        # changed_files nor file_filter is actually used. But they are accepted here because
+        # that is what Runner initializers are required to accept.
+        def initialize(changed_files: nil, file_filter: nil)
           @changed_files = changed_files
+          @file_filter = file_filter
         end
 
         def invoke!

--- a/lib/quiet_quality/tools/haml_lint/runner.rb
+++ b/lib/quiet_quality/tools/haml_lint/runner.rb
@@ -11,8 +11,9 @@ module QuietQuality
         # encountered"
         FAILURE_STATUS = 65
 
-        def initialize(changed_files: nil)
+        def initialize(changed_files: nil, file_filter: nil)
           @changed_files = changed_files
+          @file_filter = file_filter
         end
 
         def invoke!
@@ -21,7 +22,7 @@ module QuietQuality
 
         private
 
-        attr_reader :changed_files
+        attr_reader :changed_files, :file_filter
 
         def skip_execution?
           changed_files && relevant_files.empty?
@@ -29,7 +30,9 @@ module QuietQuality
 
         def relevant_files
           return nil if changed_files.nil?
-          changed_files.paths.select { |path| path.end_with?(".haml") }
+          changed_files.paths
+            .select { |path| path.end_with?(".haml") }
+            .select { |path| file_filter.nil? || file_filter.match?(path) }
         end
 
         def target_files

--- a/lib/quiet_quality/tools/rspec/runner.rb
+++ b/lib/quiet_quality/tools/rspec/runner.rb
@@ -5,8 +5,9 @@ module QuietQuality
         MAX_FILES = 100
         NO_FILES_OUTPUT = '{"examples": [], "summary": {"failure_count": 0}}'
 
-        def initialize(changed_files: nil)
+        def initialize(changed_files: nil, file_filter: nil)
           @changed_files = changed_files
+          @file_filter = file_filter
         end
 
         def invoke!
@@ -15,7 +16,7 @@ module QuietQuality
 
         private
 
-        attr_reader :changed_files
+        attr_reader :changed_files, :file_filter
 
         def skip_execution?
           changed_files && relevant_files.empty?
@@ -23,7 +24,9 @@ module QuietQuality
 
         def relevant_files
           return nil if changed_files.nil?
-          changed_files.paths.select { |path| path.end_with?("_spec.rb") }
+          changed_files.paths
+            .select { |path| path.end_with?("_spec.rb") }
+            .select { |path| file_filter.nil? || file_filter.match?(path) }
         end
 
         def target_files

--- a/lib/quiet_quality/tools/rubocop/runner.rb
+++ b/lib/quiet_quality/tools/rubocop/runner.rb
@@ -10,8 +10,9 @@ module QuietQuality
         end
 
         # Supplying changed_files: nil means "run against all files".
-        def initialize(changed_files: nil)
+        def initialize(changed_files: nil, file_filter: nil)
           @changed_files = changed_files
+          @file_filter = file_filter
         end
 
         def invoke!
@@ -20,7 +21,7 @@ module QuietQuality
 
         private
 
-        attr_reader :changed_files
+        attr_reader :changed_files, :file_filter
 
         # If we were told that _no files changed_ (which is distinct from not being told that
         # any files changed - a [] instead of a nil), then we shouldn't run rubocop at all.
@@ -38,7 +39,9 @@ module QuietQuality
 
         def relevant_files
           return nil if changed_files.nil?
-          changed_files.paths.select { |path| path.end_with?(".rb") }
+          changed_files.paths
+            .select { |path| path.end_with?(".rb") }
+            .select { |path| file_filter.nil? || file_filter.match?(path) }
         end
 
         def target_files

--- a/lib/quiet_quality/version.rb
+++ b/lib/quiet_quality/version.rb
@@ -1,3 +1,3 @@
 module QuietQuality
-  VERSION = "1.0.3"
+  VERSION = "1.1.0"
 end

--- a/spec/fixtures/configs/valid.yml
+++ b/spec/fixtures/configs/valid.yml
@@ -8,6 +8,7 @@ filter_messages: false
 rspec:
   filter_messages: false
   changed_files: false
+  file_filter: "spec/.*_spec.rb"
 standardrb:
   filter_messages: true
 rubocop:

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -256,6 +256,29 @@ RSpec.describe QuietQuality::Config::Builder do
           end
         end
       end
+
+      describe "#file_filter" do
+        let(:rspec_tool_option) { tools.detect { |t| t.tool_name == :rspec } }
+        subject(:rspec_file_filter) { rspec_tool_option.file_filter }
+
+        context "with no config file supplied" do
+          it { is_expected.to be_nil }
+        end
+
+        context "with a config file supplied" do
+          let(:global_options) { {config_path: "fake.yml"} }
+
+          context "when the config file sets it" do
+            let(:cfg_tool_options) { {rspec: {file_filter: ".*"}} }
+            it { is_expected.to eq(/.*/) }
+          end
+
+          context "when the config file does not set it" do
+            let(:cfg_tool_options) { {rspec: {filter_messages: false}} }
+            it { is_expected.to be_nil }
+          end
+        end
+      end
     end
 
     describe "config_file parsing" do

--- a/spec/quiet_quality/config/parser_spec.rb
+++ b/spec/quiet_quality/config/parser_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe QuietQuality::Config::Parser do
         filter_messages: false
       )
       expect_tool_options(
-        rspec: {filter_messages: false, changed_files: false},
-        standardrb: {filter_messages: true, changed_files: nil},
-        rubocop: {filter_messages: nil, changed_files: false}
+        rspec: {filter_messages: false, changed_files: false, file_filter: "spec/.*_spec.rb"},
+        standardrb: {filter_messages: true, changed_files: nil, file_filter: nil},
+        rubocop: {filter_messages: nil, changed_files: false, file_filter: nil}
       )
     end
 
@@ -122,6 +122,11 @@ RSpec.describe QuietQuality::Config::Parser do
         expect_config "an rspec filter_messages", %({rspec: {filter_messages: false}}), globals: {filter_messages: nil}, tools: {rspec: {filter_messages: false}}
         expect_config "both filter_messages", %({filter_messages: true, rspec: {filter_messages: false}}), globals: {filter_messages: true}, tools: {rspec: {filter_messages: false}}
         expect_invalid "a non-boolean filter_messages", %({filter_messages: "yeah"}), /either true or false/
+      end
+
+      describe "file_filter parsing" do
+        expect_config "no settings", %({}), tools: {rspec: {file_filter: nil}, rubocop: {file_filter: nil}}
+        expect_config "an rspec file_filter", %({rspec: {file_filter: "^spec/"}}), tools: {rspec: {file_filter: "^spec/"}, rubocop: {file_filter: nil}}
       end
     end
   end

--- a/spec/quiet_quality/config/tool_options_spec.rb
+++ b/spec/quiet_quality/config/tool_options_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe QuietQuality::Config::ToolOptions do
     end
   end
 
+  describe "#file_filter" do
+    subject(:file_filter) { tool_options.file_filter }
+    it { is_expected.to be_nil }
+
+    context "when set with a string" do
+      before { tool_options.file_filter = ".*" }
+      it { is_expected.to be_a(Regexp) }
+      it { is_expected.to eq(/.*/) }
+    end
+  end
+
   describe "constants for tools" do
     shared_examples "exposes the expected constants for" do |tool_name, expected_namespace|
       context "for #{tool_name}" do

--- a/spec/quiet_quality/tools/rspec/runner_spec.rb
+++ b/spec/quiet_quality/tools/rspec/runner_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe QuietQuality::Tools::Rspec::Runner do
   let(:changed_files) { nil }
-  subject(:runner) { described_class.new(changed_files: changed_files) }
+  let(:file_filter) { nil }
+  subject(:runner) { described_class.new(changed_files: changed_files, file_filter: file_filter) }
 
   let(:out) { "fake output" }
   let(:err) { "fake error" }
@@ -71,6 +72,27 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
           expect(Open3)
             .to have_received(:capture3)
             .with("rspec", "-f", "json", "a/alpha_spec.rb", "bar_spec.rb")
+        end
+
+        context "but some of them are filtered out" do
+          let(:file_filter) { /pha/ }
+          it { is_expected.to eq(build_success(:rspec, "fake output", "fake error")) }
+
+          it "calls rspec with the correct target" do
+            invoke!
+            expect(Open3)
+              .to have_received(:capture3)
+              .with("rspec", "-f", "json", "a/alpha_spec.rb")
+          end
+        end
+
+        context "but all of them are filtered out" do
+          let(:file_filter) { /nobody/ }
+          it { is_expected.to eq(build_success(:rspec, described_class::NO_FILES_OUTPUT)) }
+
+          it "does not call rspec" do
+            expect(Open3).not_to have_received(:capture3)
+          end
         end
       end
     end


### PR DESCRIPTION
Some tools sometimes need _boundaries_. In the motivating case, an application has an `engines` and a `gems` directory, and we don't want to try to run `rspec gems/foo/spec/foo/thing_spec.rb` even if that file has changes. That won't _work_ - gems and engines have their own test setups, and often their own gemfiles and bundles.

Rather than the full rubocop-style 'excludes' system, we're using a lighter approach - for each tool, you may choose to specify a `file_filter` regex in the configuration file, and that tool's Runner will avoid telling it's tool specifically to run against any file that doesn't match the regex.

(Note - this option is not available in the CLI - it didn't seem very useful there, it was awkward to specify both the tool name and the filter value in one argument, and regexes are _hard to write_ in a shell-escaped context).

The intended usage looks like this:

```
rspec:
  file_filter: "^spec/"
```

But.. it's a regex, so you can do a lot of other things, probably. I recommend not going too crazy.

Resolves #68 