### PR TITLE
Support more config options to be consistent with CLI options

### DIFF
--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -43,7 +43,9 @@ module QuietQuality
         read_global_option(opts, :annotate, :annotator, as: :symbol, validate_from: Annotators::ANNOTATOR_TYPES)
         read_global_option(opts, :comparison_branch, :comparison_branch, as: :string)
         read_global_option(opts, :changed_files, :changed_files, as: :boolean)
+        read_global_option(opts, :all_files, :changed_files, as: :reversed_boolean)
         read_global_option(opts, :filter_messages, :filter_messages, as: :boolean)
+        read_global_option(opts, :unfiltered, :filter_messages, as: :reversed_boolean)
       end
 
       def store_tool_options(opts)
@@ -92,6 +94,7 @@ module QuietQuality
       def validate_value(name, value, as:, from: nil)
         case as
         when :boolean then validate_boolean(name, value)
+        when :reversed_boolean then validate_boolean(name, value)
         when :symbol then validate_symbol(name, value, from: from)
         when :string then validate_string(name, value)
         else
@@ -124,6 +127,7 @@ module QuietQuality
       def coerce_value(value, as:)
         case as
         when :boolean then !!value
+        when :reversed_boolean then !value
         when :string then value.to_s
         when :symbol then value.to_sym
         else

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -57,8 +57,10 @@ module QuietQuality
       def store_tool_options_for(opts, tool_name)
         entries = data.fetch(tool_name, nil)
         return if entries.nil?
-        read_tool_option(opts, tool_name, :filter_messages, as: :boolean)
-        read_tool_option(opts, tool_name, :changed_files, as: :boolean)
+        read_tool_option(opts, tool_name, :filter_messages, :filter_messages, as: :boolean)
+        read_tool_option(opts, tool_name, :unfiltered, :filter_messages, as: :reversed_boolean)
+        read_tool_option(opts, tool_name, :changed_files, :changed_files, as: :boolean)
+        read_tool_option(opts, tool_name, :all_files, :changed_files, as: :reversed_boolean)
       end
 
       def invalid!(message)
@@ -82,13 +84,13 @@ module QuietQuality
         opts.set_global_option(into, coerced_value)
       end
 
-      def read_tool_option(opts, tool, name, as:)
+      def read_tool_option(opts, tool, name, into, as:)
         parsed_value = data.dig(tool.to_sym, name.to_sym)
         return if parsed_value.nil?
 
         validate_value("#{tool}.#{name}", parsed_value, as: as)
         coerced_value = coerce_value(parsed_value, as: as)
-        opts.set_tool_option(tool, name, coerced_value)
+        opts.set_tool_option(tool, into, coerced_value)
       end
 
       def validate_value(name, value, as:, from: nil)

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -38,11 +38,11 @@ module QuietQuality
       end
 
       def store_global_options(opts)
-        read_global_option(opts, :executor, as: :symbol, validate_from: Executors::AVAILABLE)
-        read_global_option(opts, :annotator, as: :symbol, validate_from: Annotators::ANNOTATOR_TYPES)
-        read_global_option(opts, :comparison_branch, as: :string)
-        read_global_option(opts, :changed_files, as: :boolean)
-        read_global_option(opts, :filter_messages, as: :boolean)
+        read_global_option(opts, :executor, :executor, as: :symbol, validate_from: Executors::AVAILABLE)
+        read_global_option(opts, :annotator, :annotator, as: :symbol, validate_from: Annotators::ANNOTATOR_TYPES)
+        read_global_option(opts, :comparison_branch, :comparison_branch, as: :string)
+        read_global_option(opts, :changed_files, :changed_files, as: :boolean)
+        read_global_option(opts, :filter_messages, :filter_messages, as: :boolean)
       end
 
       def store_tool_options(opts)
@@ -70,13 +70,13 @@ module QuietQuality
         [true, false].include?(value)
       end
 
-      def read_global_option(opts, name, as:, validate_from: nil)
+      def read_global_option(opts, name, into, as:, validate_from: nil)
         parsed_value = data.fetch(name.to_sym, nil)
         return if parsed_value.nil?
 
         validate_value(name, parsed_value, as: as, from: validate_from)
         coerced_value = coerce_value(parsed_value, as: as)
-        opts.set_global_option(name, coerced_value)
+        opts.set_global_option(into, coerced_value)
       end
 
       def read_tool_option(opts, tool, name, as:)

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -40,6 +40,7 @@ module QuietQuality
       def store_global_options(opts)
         read_global_option(opts, :executor, :executor, as: :symbol, validate_from: Executors::AVAILABLE)
         read_global_option(opts, :annotator, :annotator, as: :symbol, validate_from: Annotators::ANNOTATOR_TYPES)
+        read_global_option(opts, :annotate, :annotator, as: :symbol, validate_from: Annotators::ANNOTATOR_TYPES)
         read_global_option(opts, :comparison_branch, :comparison_branch, as: :string)
         read_global_option(opts, :changed_files, :changed_files, as: :boolean)
         read_global_option(opts, :filter_messages, :filter_messages, as: :boolean)

--- a/spec/quiet_quality/config/parser_spec.rb
+++ b/spec/quiet_quality/config/parser_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe QuietQuality::Config::Parser do
         expect_config "an rspec changed_files", %({rspec: {changed_files: false}}), globals: {changed_files: nil}, tools: {rspec: {changed_files: false}}
         expect_config "an rspec changed_files", %({rspec: {changed_files: false}}), globals: {changed_files: nil}, tools: {rspec: {changed_files: false}}
         expect_config "both changed_files", %({changed_files: true, rspec: {changed_files: false}}), globals: {changed_files: true}, tools: {rspec: {changed_files: false}}
+        expect_config "global all_files", %({all_files: false, rspec: {changed_files: false}}), globals: {changed_files: true}, tools: {rspec: {changed_files: false}}
         expect_invalid "a non-boolean changed_files", %({changed_files: "yeah"}), /either true or false/
       end
 
@@ -123,6 +124,7 @@ RSpec.describe QuietQuality::Config::Parser do
         expect_config "an rspec filter_messages", %({rspec: {filter_messages: false}}), globals: {filter_messages: nil}, tools: {rspec: {filter_messages: false}}
         expect_config "an rspec filter_messages", %({rspec: {filter_messages: false}}), globals: {filter_messages: nil}, tools: {rspec: {filter_messages: false}}
         expect_config "both filter_messages", %({filter_messages: true, rspec: {filter_messages: false}}), globals: {filter_messages: true}, tools: {rspec: {filter_messages: false}}
+        expect_config "global unfiltered", %({unfiltered: false, rspec: {filter_messages: false}}), globals: {filter_messages: true}, tools: {rspec: {filter_messages: false}}
         expect_invalid "a non-boolean filter_messages", %({filter_messages: "yeah"}), /either true or false/
       end
     end

--- a/spec/quiet_quality/config/parser_spec.rb
+++ b/spec/quiet_quality/config/parser_spec.rb
@@ -112,9 +112,10 @@ RSpec.describe QuietQuality::Config::Parser do
         expect_config "no settings", %({}), globals: {changed_files: nil}, tools: {rspec: {changed_files: nil}}
         expect_config "a global changed_files", %({changed_files: true}), globals: {changed_files: true}, tools: {rspec: {changed_files: nil}}
         expect_config "an rspec changed_files", %({rspec: {changed_files: false}}), globals: {changed_files: nil}, tools: {rspec: {changed_files: false}}
-        expect_config "an rspec changed_files", %({rspec: {changed_files: false}}), globals: {changed_files: nil}, tools: {rspec: {changed_files: false}}
+        expect_config "a global all_files", %({all_files: false}), globals: {changed_files: true}, tools: {rspec: {changed_files: nil}}
+        expect_config "an rspec all_files", %({rspec: {all_files: true}}), globals: {changed_files: nil}, tools: {rspec: {changed_files: false}}
         expect_config "both changed_files", %({changed_files: true, rspec: {changed_files: false}}), globals: {changed_files: true}, tools: {rspec: {changed_files: false}}
-        expect_config "global all_files", %({all_files: false, rspec: {changed_files: false}}), globals: {changed_files: true}, tools: {rspec: {changed_files: false}}
+        expect_config "both all_files", %({all_files: false, rspec: {all_files: true}}), globals: {changed_files: true}, tools: {rspec: {changed_files: false}}
         expect_invalid "a non-boolean changed_files", %({changed_files: "yeah"}), /either true or false/
       end
 
@@ -122,9 +123,10 @@ RSpec.describe QuietQuality::Config::Parser do
         expect_config "no settings", %({}), globals: {filter_messages: nil}, tools: {rspec: {filter_messages: nil}}
         expect_config "a global filter_messages", %({filter_messages: true}), globals: {filter_messages: true}, tools: {rspec: {filter_messages: nil}}
         expect_config "an rspec filter_messages", %({rspec: {filter_messages: false}}), globals: {filter_messages: nil}, tools: {rspec: {filter_messages: false}}
-        expect_config "an rspec filter_messages", %({rspec: {filter_messages: false}}), globals: {filter_messages: nil}, tools: {rspec: {filter_messages: false}}
+        expect_config "a global unfiltered", %({unfiltered: false}), globals: {filter_messages: true}, tools: {rspec: {filter_messages: nil}}
+        expect_config "an rspec unfiltered", %({rspec: {unfiltered: true}}), globals: {filter_messages: nil}, tools: {rspec: {filter_messages: false}}
         expect_config "both filter_messages", %({filter_messages: true, rspec: {filter_messages: false}}), globals: {filter_messages: true}, tools: {rspec: {filter_messages: false}}
-        expect_config "global unfiltered", %({unfiltered: false, rspec: {filter_messages: false}}), globals: {filter_messages: true}, tools: {rspec: {filter_messages: false}}
+        expect_config "both unfiltered", %({unfiltered: false, rspec: {unfiltered: true}}), globals: {filter_messages: true}, tools: {rspec: {filter_messages: false}}
         expect_invalid "a non-boolean filter_messages", %({filter_messages: "yeah"}), /either true or false/
       end
     end

--- a/spec/quiet_quality/config/parser_spec.rb
+++ b/spec/quiet_quality/config/parser_spec.rb
@@ -97,6 +97,8 @@ RSpec.describe QuietQuality::Config::Parser do
         expect_config "a github_stdout annotator", %({annotator: "github_stdout"}), globals: {annotator: :github_stdout}
         expect_invalid "a fooba annotator", %({annotator: "fooba"}), /one of the allowed values/
         expect_invalid "a numeric annotator", %({annotator: 5}), /string or symbol/
+        expect_config "a github_stdout annotate", %({annotate: "github_stdout"}), globals: {annotator: :github_stdout}
+        expect_invalid "a fooba annotate", %({annotate: "fooba"}), /one of the allowed values/
       end
 
       describe "comparison_branch parsing" do


### PR DESCRIPTION
Resolves #75 

The CLI takes an `--annotate` flag, but the configuration option was `annotator` - while I think the latter is a slightly better option name, it's easy to support multiple forms of config file option and painful to support multiple forms of the same CLI option. In the interest of not introducing breaking changes, we're updating the config file format to support more keys that match the keys the CLI accepts:

* You can supply `annotate: github_stdout` now, and it'll work
* You can supply `all_files: false` instead of `changed_files: true` at both the global and tool levels (and the reverse)
* You can specify `unfiltered: false` instead of `filter_messages: true` at both the global and tool levels (and the reverse)