### PR TITLE
Adds light and quiet logging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,4 +176,5 @@ The same options are all available on the CLI, plus some additional ones - run
 * `--version/-V`: what version of the gem are you using?
 * `--light/-l`: Enable light logging.
 * `--quiet/-q: Enable quiet logging.
-* `--logging/-L LEVEL: Specify logging mode that results will be returned in. Valid options: light, quiet
+* `--logging/-L LEVEL: Specify logging mode that results will be returned in.
+  Valid options: light, quiet

--- a/README.md
+++ b/README.md
@@ -160,3 +160,4 @@ The same options are all available on the CLI, plus some additional ones - run
 * `--version/-V`: what version of the gem are you using?
 * `--light/-l`: Enable light logging.
 * `--quiet/-q: Enable quiet logging.
+* `--logging/-L LEVEL: Specify logging mode that results will be returned in. Valid options: light, quiet

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ The configuration file supports the following _global_ options (top-level keys):
 * `filter_messages`: defaults to false - should the resulting messages that do
   not refer to lines that were changed or added relative to the comparison
   branch be skipped? Also possible to set for each tool.
+* `logging`: defaults to full messages printed. The `light` option
+  prints a aggregated result (e.g. "3 tools executed: 1 passed, 2 failed
+  (rubocop, standardrb)"). The `quiet` option will only return a status code,
+  printing nothing.
 
 And then each tool can have an entry, within which `changed_files` and
 `filter_messages` can be specified - the tool-specific settings override the
@@ -154,3 +158,5 @@ The same options are all available on the CLI, plus some additional ones - run
 * `--config/-C`: load the supplied config file (instead of the detected one, if
   found)
 * `--version/-V`: what version of the gem are you using?
+* `--light/-l`: Enable light logging.
+* `--quiet/-q: Enable quiet logging.

--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -65,6 +65,7 @@ module QuietQuality
           setup_annotation_options(parser)
           setup_file_target_options(parser)
           setup_filter_messages_options(parser)
+          setup_logging_options(parser)
         end
       end
 
@@ -132,6 +133,16 @@ module QuietQuality
 
         parser.on("-u", "--unfiltered [tool]", "Don't filter messages from tool(s)") do |tool|
           read_tool_or_global_option(:filter_messages, tool, false)
+        end
+      end
+
+      def setup_logging_options(parser)
+        parser.on("-l", "--light", "Print aggregated results only") do
+          set_global_option(:logging, Logging::LIGHT)
+        end
+
+        parser.on("-q", "--quiet", "Don't print results, only return a status code") do
+          set_global_option(:logging, Logging::QUIET)
         end
       end
     end

--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -144,6 +144,11 @@ module QuietQuality
         parser.on("-q", "--quiet", "Don't print results, only return a status code") do
           set_global_option(:logging, Logging::QUIET)
         end
+
+        parser.on("-L", "--logging LEVEL", "Specify logging mode that results will be returned in. Valid options: light, quiet") do |level|
+          validate_value_from("logging level", level, Logging::LEVELS)
+          set_global_option(:logging, level.to_sym)
+        end
       end
     end
   end

--- a/lib/quiet_quality/cli/entrypoint.rb
+++ b/lib/quiet_quality/cli/entrypoint.rb
@@ -45,7 +45,6 @@ module QuietQuality
         @_parsed_options ||= arg_parser.parsed_options
       end
 
-      # keep
       def helping?
         parsed_options.helping?
       end

--- a/lib/quiet_quality/cli/entrypoint.rb
+++ b/lib/quiet_quality/cli/entrypoint.rb
@@ -15,6 +15,7 @@ module QuietQuality
         else
           executed
           log_results
+          annotate_messages
         end
 
         self
@@ -34,7 +35,6 @@ module QuietQuality
 
         log_outcomes
         log_messages
-        annotate_messages
       end
 
       def arg_parser

--- a/lib/quiet_quality/config/builder.rb
+++ b/lib/quiet_quality/config/builder.rb
@@ -85,6 +85,7 @@ module QuietQuality
           update_annotator
           update_executor
           update_comparison_branch
+          update_logging
         end
 
         def update_annotator
@@ -101,6 +102,10 @@ module QuietQuality
 
         def update_comparison_branch
           set_unless_nil(options, :comparison_branch, apply.global_option(:comparison_branch))
+        end
+
+        def update_logging
+          set_unless_nil(options, :logging, apply.global_option(:logging))
         end
 
         # ---- update the tool options (apply global forms first) -------

--- a/lib/quiet_quality/config/options.rb
+++ b/lib/quiet_quality/config/options.rb
@@ -6,9 +6,15 @@ module QuietQuality
         @executor = Executors::ConcurrentExecutor
         @tools = nil
         @comparison_branch = nil
+        @logging = Logging.new
       end
 
       attr_accessor :tools, :comparison_branch, :annotator, :executor
+      attr_reader :logging
+
+      def logging=(level)
+        @logging.level = level
+      end
     end
   end
 end

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -46,7 +46,7 @@ module QuietQuality
         read_global_option(opts, :all_files, :changed_files, as: :reversed_boolean)
         read_global_option(opts, :filter_messages, :filter_messages, as: :boolean)
         read_global_option(opts, :unfiltered, :filter_messages, as: :reversed_boolean)
-        read_global_option(opts, :logging, :logging, as: :symbol, validate_from: Logging::AVAILABLE)
+        read_global_option(opts, :logging, :logging, as: :symbol, validate_from: Logging::LEVELS)
       end
 
       def store_tool_options(opts)

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -43,6 +43,7 @@ module QuietQuality
         read_global_option(opts, :comparison_branch, as: :string)
         read_global_option(opts, :changed_files, as: :boolean)
         read_global_option(opts, :filter_messages, as: :boolean)
+        read_global_option(opts, :logging, as: :symbol, validate_from: Logging::AVAILABLE)
       end
 
       def store_tool_options(opts)

--- a/lib/quiet_quality/executors/base_executor.rb
+++ b/lib/quiet_quality/executors/base_executor.rb
@@ -22,6 +22,14 @@ module QuietQuality
         pipelines.any?(&:failure?)
       end
 
+      def successful_outcomes
+        @_successful_outcomes ||= outcomes.select(&:success?)
+      end
+
+      def failed_outcomes
+        @_failed_outcomes ||= outcomes.select(&:failure?)
+      end
+
       private
 
       attr_reader :tools, :changed_files

--- a/lib/quiet_quality/logging.rb
+++ b/lib/quiet_quality/logging.rb
@@ -1,0 +1,21 @@
+module QuietQuality
+  class Logging
+    LIGHT = :light
+    QUIET = :quiet
+    AVAILABLE = [LIGHT, QUIET].freeze
+
+    attr_accessor :level
+
+    def initialize(level: nil)
+      @level = level
+    end
+
+    def light?
+      @level == LIGHT
+    end
+
+    def quiet?
+      @level == QUIET
+    end
+  end
+end

--- a/lib/quiet_quality/logging.rb
+++ b/lib/quiet_quality/logging.rb
@@ -2,7 +2,7 @@ module QuietQuality
   class Logging
     LIGHT = :light
     QUIET = :quiet
-    AVAILABLE = [LIGHT, QUIET].freeze
+    LEVELS = [LIGHT, QUIET].freeze
 
     attr_accessor :level
 

--- a/spec/fixtures/configs/valid.yml
+++ b/spec/fixtures/configs/valid.yml
@@ -4,6 +4,7 @@ executor: concurrent
 comparison_branch: master
 changed_files: true
 filter_messages: false
+logging: light
 
 rspec:
   filter_messages: false

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe QuietQuality::Cli::ArgParser do
             -u, --unfiltered [tool]          Don't filter messages from tool(s)
             -l, --light                      Print aggregated results only
             -q, --quiet                      Don't print results, only return a status code
+            -L, --logging LEVEL              Specify logging mode that results will be returned in. Valid options: light, quiet
       HELP_OUTPUT
     end
   end
@@ -147,6 +148,11 @@ RSpec.describe QuietQuality::Cli::ArgParser do
       expect_options("-lq", ["-lq"], global: {logging: :quiet})
       expect_options("-ql", ["-ql"], global: {logging: :light})
       expect_options("no logging option passed", [], global: {logging: nil})
+      expect_options("--logging light", ["--logging", "light"], global: {logging: :light})
+      expect_options("-Llight", ["-Llight"], global: {logging: :light})
+      expect_options("--logging quiet", ["--logging", "quiet"], global: {logging: :quiet})
+      expect_options("-Lquiet", ["-Lquiet"], global: {logging: :quiet})
+      expect_usage_error("-Lshenanigans", ["-Lshenanigans"], /Unrecognized logging level/i)
     end
 
     describe "file targeting options" do

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe QuietQuality::Cli::ArgParser do
       expect_options("--quiet", ["--quiet"], global: {logging: :quiet})
       expect_options("-lq", ["-lq"], global: {logging: :quiet})
       expect_options("-ql", ["-ql"], global: {logging: :light})
+      expect_options("no logging option passed", [], global: {logging: nil})
     end
 
     describe "file targeting options" do

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe QuietQuality::Cli::ArgParser do
             -B, --comparison-branch BRANCH   Specify the branch to compare against
             -f, --filter-messages [tool]     Filter messages from tool(s) based on changed lines
             -u, --unfiltered [tool]          Don't filter messages from tool(s)
+            -l, --light                      Print aggregated results only
+            -q, --quiet                      Don't print results, only return a status code
       HELP_OUTPUT
     end
   end
@@ -135,6 +137,15 @@ RSpec.describe QuietQuality::Cli::ArgParser do
       expect_options("-G", ["-G"], global: {annotator: :github_stdout})
       expect_usage_error("--annotate foo_bar", ["--annotate", "foo_bar"], /Unrecognized annotator/i)
       expect_usage_error("-Afoo_bar", ["-Afoo_bar"], /Unrecognized annotator/i)
+    end
+
+    describe "logging options" do
+      expect_options("-l", ["-l"], global: {logging: :light})
+      expect_options("--light", ["--light"], global: {logging: :light})
+      expect_options("-q", ["-q"], global: {logging: :quiet})
+      expect_options("--quiet", ["--quiet"], global: {logging: :quiet})
+      expect_options("-lq", ["-lq"], global: {logging: :quiet})
+      expect_options("-ql", ["-ql"], global: {logging: :light})
     end
 
     describe "file targeting options" do

--- a/spec/quiet_quality/cli/entrypoint_spec.rb
+++ b/spec/quiet_quality/cli/entrypoint_spec.rb
@@ -71,6 +71,15 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
       it { is_expected.to eq(entrypoint) }
       it { is_expected.not_to be_successful }
 
+      shared_examples "annotations are requested" do
+        it "writes the proper annotations to stdout" do
+          execute
+          expect(output_stream).to have_received(:puts).with("::warning file=foo.rb,line=1::Msg1")
+          expect(output_stream).to have_received(:puts).with("::warning file=bar.rb,line=2,title=Title::Msg2")
+          expect(output_stream).to have_received(:puts).with("::warning file=baz.rb,line=5::Msg3")
+        end
+      end
+
       it "logs the outcomes properly" do
         execute
         expect(error_stream).to have_received(:puts).with("--- Failed: rspec")
@@ -87,12 +96,7 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
       context "when annotation is requested" do
         let(:argv) { ["--annotate", "github_stdout"] }
 
-        it "writes the proper annotations to stdout" do
-          execute
-          expect(output_stream).to have_received(:puts).with("::warning file=foo.rb,line=1::Msg1")
-          expect(output_stream).to have_received(:puts).with("::warning file=bar.rb,line=2,title=Title::Msg2")
-          expect(output_stream).to have_received(:puts).with("::warning file=baz.rb,line=5::Msg3")
-        end
+        include_examples "annotations are requested"
       end
 
       context "when annotation is not requested" do
@@ -111,6 +115,12 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
           execute
           expect(output_stream).not_to have_received(:puts)
           expect(error_stream).not_to have_received(:puts)
+        end
+
+        context "with annotations requested" do
+          let(:argv) { ["--quiet", "--annotate", "github_stdout"] }
+
+          include_examples "annotations are requested"
         end
       end
 
@@ -135,6 +145,12 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
           expect(output_stream).to have_received(:puts).with(
             "2 tools executed: 1 passed, 1 failed (rspec)"
           )
+        end
+
+        context "when annotations are requested" do
+          let(:argv) { ["--light", "--annotate", "github_stdout"] }
+
+          include_examples "annotations are requested"
         end
       end
     end

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -256,6 +256,38 @@ RSpec.describe QuietQuality::Config::Builder do
           end
         end
       end
+
+      describe "#logging" do
+        subject(:logging) { options.logging.level }
+
+        context "when global_options[:logging] is unset" do
+          let(:global_options) { {} }
+          it { is_expected.to be_nil }
+        end
+
+        context "when global_options[:logging] is specified" do
+          let(:global_options) { {logging: :quiet} }
+          it { is_expected.to eq(:quiet) }
+        end
+
+        context "when a config file is passed" do
+          let(:global_options) { {config_path: "/fake.yml", logging: cli_logging} }
+
+          context "when the config file sets the logging" do
+            let(:cfg_global_options) { {logging: :light} }
+
+            context "and the cli does not" do
+              let(:cli_logging) { nil }
+              it { is_expected.to eq(:light) }
+            end
+
+            context "and the cli sets a different one" do
+              let(:cli_logging) { :quiet }
+              it { is_expected.to eq(:quiet) }
+            end
+          end
+        end
+      end
     end
 
     describe "config_file parsing" do

--- a/spec/quiet_quality/config/options_spec.rb
+++ b/spec/quiet_quality/config/options_spec.rb
@@ -6,10 +6,18 @@ RSpec.describe QuietQuality::Config::Options do
     expect(options.executor).to eq(QuietQuality::Executors::ConcurrentExecutor)
     expect(options.comparison_branch).to be_nil
     expect(options.tools).to be_nil
+    expect(options.logging).to be_a(QuietQuality::Logging)
   end
 
   it { is_expected.to respond_to(:tools=) }
   it { is_expected.to respond_to(:annotator=) }
   it { is_expected.to respond_to(:executor=) }
   it { is_expected.to respond_to(:comparison_branch=) }
+
+  describe "#logging=" do
+    it "sets the logging level" do
+      options.logging = :light
+      expect(options.logging.light?).to be true
+    end
+  end
 end

--- a/spec/quiet_quality/config/parser_spec.rb
+++ b/spec/quiet_quality/config/parser_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe QuietQuality::Config::Parser do
         annotator: nil,
         comparison_branch: "master",
         changed_files: true,
-        filter_messages: false
+        filter_messages: false,
+        logging: :light
       )
       expect_tool_options(
         rspec: {filter_messages: false, changed_files: false},
@@ -122,6 +123,15 @@ RSpec.describe QuietQuality::Config::Parser do
         expect_config "an rspec filter_messages", %({rspec: {filter_messages: false}}), globals: {filter_messages: nil}, tools: {rspec: {filter_messages: false}}
         expect_config "both filter_messages", %({filter_messages: true, rspec: {filter_messages: false}}), globals: {filter_messages: true}, tools: {rspec: {filter_messages: false}}
         expect_invalid "a non-boolean filter_messages", %({filter_messages: "yeah"}), /either true or false/
+      end
+
+      describe "logging parsing" do
+        expect_config "no logging", %({}), globals: {comparison_branch: nil}
+        expect_config "the valid 'light' logging option", %({logging: "light"}), globals: {logging: :light}
+        expect_config "the valid 'quiet' logging option", %({logging: "quiet"}), globals: {logging: :quiet}
+        expect_invalid "a numeric logging option", %({logging: 5}), /must be a string/
+        expect_invalid "an empty logging option", %({logging: ""}), /option logging must be one of the allowed values/
+        expect_invalid "an invalid logging option", %({logging: shecklackity}), /option logging must be one of the allowed values/
       end
     end
   end

--- a/spec/quiet_quality/executors/executor_examples.rb
+++ b/spec/quiet_quality/executors/executor_examples.rb
@@ -58,4 +58,18 @@ shared_examples "executes the pipelines" do
       it { is_expected.to be_truthy }
     end
   end
+
+  describe "#failed_outcomes" do
+    subject(:failed_outcomes) { executor.failed_outcomes }
+    let(:rubocop_outcome) { build_failure(:rubocop, "rubocop output") }
+
+    it { is_expected.to contain_exactly(rubocop_outcome) }
+  end
+
+  describe "#successful_outcomes" do
+    subject(:successful_outcomes) { executor.successful_outcomes }
+    let(:rubocop_outcome) { build_failure(:rubocop, "rubocop output") }
+
+    it { is_expected.to contain_exactly(rspec_outcome) }
+  end
 end

--- a/spec/quiet_quality/logging_spec.rb
+++ b/spec/quiet_quality/logging_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe QuietQuality::Logging do
+  describe "#light?" do
+    subject { described_class.new(level: level).light? }
+
+    context "level is nil" do
+      let(:level) { nil }
+      it { is_expected.to be(false) }
+    end
+
+    context "level is :light" do
+      let(:level) { described_class::LIGHT }
+      it { is_expected.to be(true) }
+    end
+
+    context "level is :quiet" do
+      let(:level) { described_class::QUIET }
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#quiet?" do
+    subject { described_class.new(level: level).quiet? }
+
+    context "level is nil" do
+      let(:level) { nil }
+      it { is_expected.to be(false) }
+    end
+
+    context "level is :light" do
+      let(:level) { described_class::LIGHT }
+      it { is_expected.to be(false) }
+    end
+
+    context "level is :quiet" do
+      let(:level) { described_class::QUIET }
+      it { is_expected.to be(true) }
+    end
+  end
+
+  describe "#level" do
+    it "returns the level" do
+      expect(described_class.new(level: :light).level).to eq(:light)
+      expect(described_class.new(level: :quiet).level).to eq(:quiet)
+      expect(described_class.new.level).to be_nil
+    end
+  end
+
+  describe "#level=" do
+    it "sets the level" do
+      logging = described_class.new
+      expect { logging.level = :light }.to change { logging.level }.from(nil).to(:light)
+    end
+  end
+end

--- a/spec/support/option_setup.rb
+++ b/spec/support/option_setup.rb
@@ -15,15 +15,22 @@ module OptionSetup
 
   def build_options(**attrs)
     opts = QuietQuality::Config::Options.new
-    opts.comparison_branch = attrs[:comparison_branch]
-    opts.annotator = annotator_from(attrs[:annotator]) if attrs[:annotator]
-    opts.executor = executor_from(attrs[:executor]) if attrs[:executor]
-    opts.logging = attrs[:logging]
+    [:comparison_branch, :annotator, :executor, :logging].each do |attr|
+      opts.send("#{attr}=", send("#{attr}_from", attrs[attr])) if attrs[attr]
+    end
     opts.tools = tool_options_from(attrs)
     opts
   end
 
   private
+
+  def comparison_branch_from(name)
+    name
+  end
+
+  def logging_from(level)
+    level
+  end
 
   def set_global_options(po, global_options)
     global_options.each_pair { |name, value| po.set_global_option(name, value) }


### PR DESCRIPTION
Passing `-l` or `--light` will print out aggregated results only. Passing `-q` or `--quiet` won't print anything at all. Also configurable via config file.

[UPDATED]
You can now pass a logging level (`light` or `quiet`) to `--logging` or `-L` as well.

Resolves https://github.com/nevinera/quiet_quality/issues/37

<img width="1502" alt="Screenshot 2023-05-25 at 9 41 50 PM" src="https://github.com/nevinera/quiet_quality/assets/22665228/ff57a92d-a1c1-48f2-9059-3a2f99c76760">

<img width="1510" alt="Screenshot 2023-05-25 at 9 42 22 PM" src="https://github.com/nevinera/quiet_quality/assets/22665228/b5c4d5ab-1663-45dd-bbf0-8ddf21de54e0">

<img width="1512" alt="Screenshot 2023-05-26 at 9 58 23 PM" src="https://github.com/nevinera/quiet_quality/assets/22665228/25ed7051-8564-48ea-b78e-3f41271e6621">

