### PR TITLE
Abort and explain when unsure what tools to run

### DIFF
--- a/lib/quiet_quality/cli/entrypoint.rb
+++ b/lib/quiet_quality/cli/entrypoint.rb
@@ -12,6 +12,8 @@ module QuietQuality
           log_help_text
         elsif printing_version?
           log_version_text
+        elsif no_tools?
+          log_no_tools_text
         else
           executed
           log_outcomes
@@ -23,7 +25,9 @@ module QuietQuality
       end
 
       def successful?
-        helping? || printing_version? || !executed.any_failure?
+        return true if helping? || printing_version?
+        return false if no_tools?
+        !executed.any_failure?
       end
 
       private
@@ -46,12 +50,23 @@ module QuietQuality
         parsed_options.printing_version?
       end
 
+      def no_tools?
+        options.tools.empty?
+      end
+
       def log_help_text
         error_stream.puts(arg_parser.help_text)
       end
 
       def log_version_text
         error_stream.puts(QuietQuality::VERSION)
+      end
+
+      def log_no_tools_text
+        error_stream.puts(<<~TEXT)
+          You must specify one or more tools to run, either on the command-line or in the
+          default_tools key in a configuration file.
+        TEXT
       end
 
       def options

--- a/lib/quiet_quality/config/builder.rb
+++ b/lib/quiet_quality/config/builder.rb
@@ -28,7 +28,7 @@ module QuietQuality
         elsif config_file&.tools&.any?
           config_file.tools
         else
-          Tools::AVAILABLE.keys
+          []
         end
       end
 

--- a/spec/quiet_quality/cli/entrypoint_spec.rb
+++ b/spec/quiet_quality/cli/entrypoint_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
   let(:git) { instance_double(QuietQuality::VersionControlSystems::Git, changed_files: changed_files) }
   before { allow(QuietQuality::VersionControlSystems::Git).to receive(:new).and_return(git) }
 
+  let(:options) { build_options(rubocop: {}, rspec: {}) }
+  let(:config_builder) { instance_double(QuietQuality::Config::Builder, options: options) }
+  before { allow(QuietQuality::Config::Builder).to receive(:new).and_return(config_builder) }
+
   describe "#execute" do
     subject(:execute) { entrypoint.execute }
 
@@ -76,6 +80,7 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
 
       context "when annotation is requested" do
         let(:argv) { ["--annotate", "github_stdout"] }
+        let(:options) { build_options(annotator: :github_stdout, rubocop: {}, rspec: {}) }
 
         it "writes the proper annotations to stdout" do
           execute

--- a/spec/quiet_quality/cli/entrypoint_spec.rb
+++ b/spec/quiet_quality/cli/entrypoint_spec.rb
@@ -131,6 +131,22 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
         expect(error_stream).to have_received(:puts).with(QuietQuality::VERSION)
       end
     end
+
+    context "when there are no tools to run" do
+      let(:options) { build_options(annotator: :github_stdout) }
+
+      it "does not run the executor" do
+        execute
+        expect(executor).not_to have_received(:execute!)
+      end
+
+      it "prints the corrective instructions to the error stream" do
+        execute
+        expect(error_stream)
+          .to have_received(:puts)
+          .with(a_string_matching(/specify one or more tools to run/))
+      end
+    end
   end
 
   describe "#successful?" do

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -118,9 +118,7 @@ RSpec.describe QuietQuality::Config::Builder do
       context "when there are no tools specified on the cli" do
         let(:tool_names) { [] }
 
-        it "exposes all of the tools" do
-          expect(tools.map(&:tool_name)).to match_array(QuietQuality::Tools::AVAILABLE.keys)
-        end
+        it { is_expected.to be_empty }
 
         context "but there are some specified in a config file" do
           let(:global_options) { {config_path: "fake.yml"} }

--- a/spec/support/option_setup.rb
+++ b/spec/support/option_setup.rb
@@ -13,6 +13,15 @@ module OptionSetup
     po
   end
 
+  def build_options(**attrs)
+    opts = QuietQuality::Config::Options.new
+    opts.comparison_branch = attrs[:comparison_branch]
+    opts.annotator = annotator_from(attrs[:annotator]) if attrs[:annotator]
+    opts.executor = executor_from(attrs[:executor]) if attrs[:executor]
+    opts.tools = tool_options_from(attrs)
+    opts
+  end
+
   private
 
   def set_global_options(po, global_options)
@@ -23,6 +32,22 @@ module OptionSetup
     tool_options.each_pair do |tool, specifics|
       specifics.each_pair { |name, value| po.set_tool_option(tool, name, value) }
     end
+  end
+
+  def annotator_from(name)
+    QuietQuality::Annotators::ANNOTATOR_TYPES.fetch(name)
+  end
+
+  def executor_from(name)
+    QuietQuality::Executors::AVAILABLE.fetch(name)
+  end
+
+  def tool_options_from(attrs)
+    tool_options = []
+    QuietQuality::Tools::AVAILABLE.each_key do |tool_name|
+      tool_options << tool_options(tool_name, **attrs[tool_name]) if attrs[tool_name]
+    end
+    tool_options
   end
 end
 


### PR DESCRIPTION
We originally just ran "all the tools" when not told what to run. Which was a little short-sighted, but the original implementation was a script we only ran against the repository itself, and only executed rspec/standardrb/rubocop, so it didn't hurt anything. That doesn't make sense now - if you haven't told us which tools to run, we need to stop and complain about that.

Incidentally, set up a better way to generate Options objects for specs, since the Entrypoint needs it (it turns out it was actually parsing the real repo's config file, and the specs were passing because the Executor was mocked. But now we care about some other bits of the config.)

Resolves #58 