### PR TITLE
Extract a BaseRunner class

### DIFF
--- a/lib/quiet_quality/tools.rb
+++ b/lib/quiet_quality/tools.rb
@@ -8,6 +8,8 @@ module QuietQuality
   end
 end
 
+require_relative "./tools/base_runner"
+
 glob = File.expand_path("../tools/*.rb", __FILE__)
 Dir.glob(glob).sort.each { |f| require f }
 

--- a/lib/quiet_quality/tools.rb
+++ b/lib/quiet_quality/tools.rb
@@ -3,6 +3,8 @@ require "open3"
 module QuietQuality
   module Tools
     Error = Class.new(::QuietQuality::Error)
+    ExecutionError = Class.new(Error)
+    ParsingError = Class.new(Error)
   end
 end
 

--- a/lib/quiet_quality/tools/base_runner.rb
+++ b/lib/quiet_quality/tools/base_runner.rb
@@ -1,0 +1,49 @@
+module QuietQuality
+  module Tools
+    class BaseRunner
+      # In general, we don't want to supply a huge number of arguments to a command-line tool.
+      MAX_FILES = 100
+
+      def initialize(changed_files: nil, file_filter: nil)
+        @changed_files = changed_files
+        @file_filter = file_filter
+      end
+
+      def invoke!
+        @_outcome ||= performed_outcome
+      end
+
+      def tool_name
+        fail(NoMethodError, "BaseRunner subclass must implement `tool_name`")
+      end
+
+      def command
+        fail(NoMethodError, "BaseRunner subclass must implement `command`")
+      end
+
+      def success_status?(stat)
+        stat.success?
+      end
+
+      # distinct from _error_ status - this is asking "does this status represent failures-found?"
+      def failure_status?(stat)
+        stat.exitstatus == 1
+      end
+
+      private
+
+      attr_reader :changed_files, :file_filter
+
+      def performed_outcome
+        out, err, stat = Open3.capture3(*command)
+        if success_status?(stat)
+          Outcome.new(tool: tool_name, output: out, logging: err)
+        elsif failure_status?(stat)
+          Outcome.new(tool: tool_name, output: out, logging: err, failure: true)
+        else
+          fail(ExecutionError, "Execution of #{tool_name} failed with #{stat.exitstatus}")
+        end
+      end
+    end
+  end
+end

--- a/lib/quiet_quality/tools/brakeman.rb
+++ b/lib/quiet_quality/tools/brakeman.rb
@@ -3,8 +3,6 @@ require_relative "./rubocop"
 module QuietQuality
   module Tools
     module Brakeman
-      ExecutionError = Class.new(Tools::Error)
-      ParsingError = Class.new(Tools::Error)
     end
   end
 end

--- a/lib/quiet_quality/tools/brakeman/runner.rb
+++ b/lib/quiet_quality/tools/brakeman/runner.rb
@@ -1,38 +1,19 @@
 module QuietQuality
   module Tools
     module Brakeman
-      class Runner
-        # These are specified in constants at the top of brakeman.rb:
-        #   https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman.rb#L6-L25
-        KNOWN_EXIT_STATUSES = [3, 4, 5, 6, 7, 8].to_set
-
-        # brakeman does not support being run against a portion of the project, so neither
-        # changed_files nor file_filter is actually used. But they are accepted here because
-        # that is what Runner initializers are required to accept.
-        def initialize(changed_files: nil, file_filter: nil)
-          @changed_files = changed_files
-          @file_filter = file_filter
+      class Runner < BaseRunner
+        def tool_name
+          :brakeman
         end
-
-        def invoke!
-          @_outcome ||= performed_outcome
-        end
-
-        private
 
         def command
           ["brakeman", "-f", "json"]
         end
 
-        def performed_outcome
-          out, err, stat = Open3.capture3(*command)
-          if stat.success?
-            Outcome.new(tool: :brakeman, output: out, logging: err)
-          elsif KNOWN_EXIT_STATUSES.include?(stat.exitstatus)
-            Outcome.new(tool: :brakeman, output: out, logging: err, failure: true)
-          else
-            fail(ExecutionError, "Execution of brakeman failed with #{stat.exitstatus}")
-          end
+        # These are specified in constants at the top of brakeman.rb:
+        #   https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman.rb#L6-L25
+        def failure_status?(stat)
+          [3, 4, 5, 6, 7, 8].include?(stat.exitstatus)
         end
       end
     end

--- a/lib/quiet_quality/tools/haml_lint.rb
+++ b/lib/quiet_quality/tools/haml_lint.rb
@@ -1,8 +1,6 @@
 module QuietQuality
   module Tools
     module HamlLint
-      ExecutionError = Class.new(Tools::Error)
-      ParsingError = Class.new(Tools::Error)
     end
   end
 end

--- a/lib/quiet_quality/tools/markdown_lint.rb
+++ b/lib/quiet_quality/tools/markdown_lint.rb
@@ -1,8 +1,6 @@
 module QuietQuality
   module Tools
     module MarkdownLint
-      ExecutionError = Class.new(Tools::Error)
-      ParsingError = Class.new(Tools::Error)
     end
   end
 end

--- a/lib/quiet_quality/tools/rspec.rb
+++ b/lib/quiet_quality/tools/rspec.rb
@@ -1,8 +1,6 @@
 module QuietQuality
   module Tools
     module Rspec
-      ExecutionError = Class.new(Tools::Error)
-      ParsingError = Class.new(Tools::Error)
     end
   end
 end

--- a/lib/quiet_quality/tools/rubocop.rb
+++ b/lib/quiet_quality/tools/rubocop.rb
@@ -1,8 +1,6 @@
 module QuietQuality
   module Tools
     module Rubocop
-      ExecutionError = Class.new(Tools::Error)
-      ParsingError = Class.new(Tools::Error)
     end
   end
 end

--- a/lib/quiet_quality/tools/standardrb.rb
+++ b/lib/quiet_quality/tools/standardrb.rb
@@ -3,8 +3,6 @@ require_relative "./rubocop"
 module QuietQuality
   module Tools
     module Standardrb
-      ExecutionError = Class.new(Tools::Error)
-      ParsingError = Class.new(Tools::Error)
     end
   end
 end

--- a/spec/quiet_quality/tools/base_runner_spec.rb
+++ b/spec/quiet_quality/tools/base_runner_spec.rb
@@ -1,3 +1,5 @@
+require_relative "./runner_examples"
+
 RSpec.describe QuietQuality::Tools::BaseRunner do
   let(:changed_files) { instance_double(QuietQuality::ChangedFiles) }
   let(:file_filter) { instance_double(Regexp) }
@@ -120,5 +122,7 @@ RSpec.describe QuietQuality::Tools::BaseRunner do
         end
       end
     end
+
+    it_behaves_like "a functional BaseRunner subclass", :fake_tool, runner_class_method: :subclass
   end
 end

--- a/spec/quiet_quality/tools/base_runner_spec.rb
+++ b/spec/quiet_quality/tools/base_runner_spec.rb
@@ -1,0 +1,124 @@
+RSpec.describe QuietQuality::Tools::BaseRunner do
+  let(:changed_files) { instance_double(QuietQuality::ChangedFiles) }
+  let(:file_filter) { instance_double(Regexp) }
+  subject(:runner) { subclass.new(changed_files: changed_files, file_filter: file_filter) }
+
+  context "with an improperly implemented subclass" do
+    let(:subclass) { Class.new(described_class) }
+
+    describe "#invoke!" do
+      subject(:invoke!) { runner.invoke! }
+
+      it "raises a NoMethodError" do
+        expect { invoke! }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "#tool_name" do
+      subject(:tool_name) { runner.tool_name }
+
+      it "raises a NoMethodError" do
+        expect { tool_name }.to raise_error(NoMethodError, /must implement.*tool_name/i)
+      end
+    end
+
+    describe "#command" do
+      subject(:command) { runner.command }
+
+      it "raises a NoMethodError" do
+        expect { command }.to raise_error(NoMethodError, /must implement.*command/i)
+      end
+    end
+  end
+
+  context "with a properly implemented subclass" do
+    let(:subclass) do
+      Class.new(described_class) do
+        def tool_name
+          :fake_tool
+        end
+
+        def command
+          ["fake", "command"]
+        end
+      end
+    end
+
+    describe "#success_status?" do
+      subject(:success_status?) { runner.success_status?(stat) }
+
+      context "for an exit status of 0" do
+        let(:stat) { mock_status(0) }
+        it { is_expected.to be_truthy }
+      end
+
+      context "for an exit status of 1" do
+        let(:stat) { mock_status(1) }
+        it { is_expected.to be_falsey }
+      end
+
+      context "for an exit status of 99" do
+        let(:stat) { mock_status(99) }
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    describe "#failure_status?" do
+      subject(:failure_status) { runner.failure_status?(stat) }
+
+      context "for an exit status of 0" do
+        let(:stat) { mock_status(0) }
+        it { is_expected.to be_falsey }
+      end
+
+      context "for an exit status of 1" do
+        let(:stat) { mock_status(1) }
+        it { is_expected.to be_truthy }
+      end
+
+      context "for an exit status of 99" do
+        let(:stat) { mock_status(99) }
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    describe "#invoke!" do
+      subject(:invoke!) { runner.invoke! }
+
+      let(:out) { "fake stdout" }
+      let(:err) { "fake stderr" }
+      before { allow(Open3).to receive(:capture3).and_return([out, err, stat]) }
+
+      context "when successful" do
+        let(:stat) { mock_status(0) }
+        it { is_expected.to eq(build_outcome(tool: :fake_tool, output: out, logging: err, failure: false)) }
+
+        it "invokes the command correctly" do
+          invoke!
+          expect(Open3).to have_received(:capture3).with("fake", "command")
+        end
+      end
+
+      context "when failures found" do
+        let(:stat) { mock_status(1) }
+        it { is_expected.to eq(build_outcome(tool: :fake_tool, output: out, logging: err, failure: true)) }
+
+        it "invokes the command correctly" do
+          invoke!
+          expect(Open3).to have_received(:capture3).with("fake", "command")
+        end
+      end
+
+      context "when an unexpected status is encountered" do
+        let(:stat) { mock_status(99) }
+
+        it "raises an ExecutionError" do
+          expect { invoke! }.to raise_error(
+            QuietQuality::Tools::ExecutionError,
+            /Execution of fake_tool failed with 99/
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/tools/brakeman/parser_spec.rb
+++ b/spec/quiet_quality/tools/brakeman/parser_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe QuietQuality::Tools::Brakeman::Parser do
 
       it "raises a ParsingError" do
         expect { messages }.to raise_error(
-          QuietQuality::Tools::Brakeman::ParsingError,
+          QuietQuality::Tools::ParsingError,
           /Found 2 errors/
         )
       end

--- a/spec/quiet_quality/tools/brakeman/runner_spec.rb
+++ b/spec/quiet_quality/tools/brakeman/runner_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe QuietQuality::Tools::Brakeman::Runner do
     context "when the brakeman command fails" do
       let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
 
-      it "raises a Brakeman::ExecutionError" do
-        expect { invoke! }.to raise_error(QuietQuality::Tools::Brakeman::ExecutionError)
+      it "raises an ExecutionError" do
+        expect { invoke! }.to raise_error(QuietQuality::Tools::ExecutionError)
       end
     end
 

--- a/spec/quiet_quality/tools/brakeman/runner_spec.rb
+++ b/spec/quiet_quality/tools/brakeman/runner_spec.rb
@@ -1,41 +1,23 @@
+require_relative "../runner_examples"
+
 RSpec.describe QuietQuality::Tools::Brakeman::Runner do
   let(:changed_files) { nil }
   subject(:runner) { described_class.new }
 
-  let(:out) { "fake output" }
-  let(:err) { "fake error" }
-  let(:stat) { instance_double(Process::Status, success?: true, exitstatus: 0) }
-  before { allow(Open3).to receive(:capture3).and_return([out, err, stat]) }
+  describe "#tool_name" do
+    subject(:tool_name) { runner.tool_name }
+    it { is_expected.to eq(:brakeman) }
+  end
 
-  describe "#invoke!" do
-    subject(:invoke!) { runner.invoke! }
+  describe "#command" do
+    subject(:command) { runner.command }
+    it { is_expected.to eq(["brakeman", "-f", "json"]) }
+  end
 
-    context "when the brakeman command fails" do
-      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
-
-      it "raises an ExecutionError" do
-        expect { invoke! }.to raise_error(QuietQuality::Tools::ExecutionError)
-      end
-    end
-
-    context "when the brakeman command finds warnings" do
-      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 3) }
-      it { is_expected.to eq(build_failure(:brakeman, "fake output", "fake error")) }
-
-      it "calls brakeman correctly" do
-        invoke!
-        expect(Open3).to have_received(:capture3).with("brakeman", "-f", "json")
-      end
-    end
-
-    context "when the brakeman command finds no problems" do
-      let(:stat) { instance_double(Process::Status, success?: true, exitstatus: 0) }
-      it { is_expected.to eq(build_success(:brakeman, "fake output", "fake error")) }
-
-      it "calls brakeman correctly" do
-        invoke!
-        expect(Open3).to have_received(:capture3).with("brakeman", "-f", "json")
-      end
+  it_behaves_like "a functional BaseRunner subclass", :brakeman, failure: (3..8) do
+    it "calls brakeman correctly" do
+      runner.invoke!
+      expect(Open3).to have_received(:capture3).with("brakeman", "-f", "json")
     end
   end
 end

--- a/spec/quiet_quality/tools/haml_lint/runner_spec.rb
+++ b/spec/quiet_quality/tools/haml_lint/runner_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe QuietQuality::Tools::HamlLint::Runner do
     context "when haml-lint fails" do
       let(:exitstatus) { 3 }
 
-      it "raises a HamlLint::ExecutionError" do
-        expect { invoke! }.to raise_error(QuietQuality::Tools::HamlLint::ExecutionError)
+      it "raises an ExecutionError" do
+        expect { invoke! }.to raise_error(QuietQuality::Tools::ExecutionError)
       end
     end
 

--- a/spec/quiet_quality/tools/markdown_lint/runner_spec.rb
+++ b/spec/quiet_quality/tools/markdown_lint/runner_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe QuietQuality::Tools::MarkdownLint::Runner do
     context "when mdl fails" do
       let(:exitstatus) { 3 }
 
-      it "raises a MarkdownLint::ExecutionError" do
-        expect { invoke! }.to raise_error(QuietQuality::Tools::MarkdownLint::ExecutionError)
+      it "raises an ExecutionError" do
+        expect { invoke! }.to raise_error(QuietQuality::Tools::ExecutionError)
       end
     end
 

--- a/spec/quiet_quality/tools/rspec/runner_spec.rb
+++ b/spec/quiet_quality/tools/rspec/runner_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
     context "when the rspec command fails" do
       let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
 
-      it "raises an Rspec::ExecutionError" do
-        expect { invoke! }.to raise_error(QuietQuality::Tools::Rspec::ExecutionError)
+      it "raises an ExecutionError" do
+        expect { invoke! }.to raise_error(QuietQuality::Tools::ExecutionError)
       end
     end
 

--- a/spec/quiet_quality/tools/rubocop/runner_spec.rb
+++ b/spec/quiet_quality/tools/rubocop/runner_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe QuietQuality::Tools::Rubocop::Runner do
     context "when the rubocop command _fails_" do
       let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
 
-      it "raises a Rubocop::ExecutionError" do
-        expect { invoke! }.to raise_error(QuietQuality::Tools::Rubocop::ExecutionError)
+      it "raises an ExecutionError" do
+        expect { invoke! }.to raise_error(QuietQuality::Tools::ExecutionError)
       end
     end
 

--- a/spec/quiet_quality/tools/runner_examples.rb
+++ b/spec/quiet_quality/tools/runner_examples.rb
@@ -1,0 +1,51 @@
+shared_examples "a functional BaseRunner subclass" do |tool_name, opts|
+  success_statuses = opts.fetch(:success, [0])
+  failure_statuses = opts.fetch(:failure, [1])
+  error_statuses = opts.fetch(:error, [99])
+
+  if opts[:runner_class_method]
+    let(:runner_class) { send opts[:runner_class_method] }
+  else
+    let(:runner_class) { described_class }
+  end
+
+  # While it's possible for a BaseRunner to use these parameters, nothing implemented within
+  # BaseRunner itself references them.
+  let(:runner) { runner_class.new(changed_files: nil, file_filter: nil) }
+
+  let(:out) { "fake stdout" }
+  let(:err) { "fake stderr" }
+  let(:stat) { mock_status(success_statuses.first) }
+  before { allow(Open3).to receive(:capture3).and_return([out, err, stat]) }
+
+  describe "#invoke!" do
+    subject(:invoke!) { runner.invoke! }
+
+    success_statuses.each do |success_status|
+      context "with a (successful) exit status of #{success_status}" do
+        let(:stat) { mock_status(success_status) }
+        it { is_expected.to eq(build_outcome(tool: runner.tool_name, output: out, logging: err, failure: false)) }
+      end
+    end
+
+    failure_statuses.each do |failure_status|
+      context "with a (failing) exit status of #{failure_status}" do
+        let(:stat) { mock_status(failure_status) }
+        it { is_expected.to eq(build_outcome(tool: runner.tool_name, output: out, logging: err, failure: true)) }
+      end
+    end
+
+    error_statuses.each do |error_status|
+      context "with an (unexpected) exit status of #{error_status}" do
+        let(:stat) { mock_status(error_status) }
+
+        it "raises an ExecutionError" do
+          expect { invoke! }.to raise_error(
+            QuietQuality::Tools::ExecutionError,
+            /Execution of #{runner.tool_name} failed with #{error_status}/
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/tools/standardrb/runner_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/runner_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
     context "when the standardrb command _fails_" do
       let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
 
-      it "raises a Rubocop::ExecutionError" do
-        expect { invoke! }.to raise_error(QuietQuality::Tools::Rubocop::ExecutionError)
+      it "raises an ExecutionError" do
+        expect { invoke! }.to raise_error(QuietQuality::Tools::ExecutionError)
       end
     end
 


### PR DESCRIPTION
There's more, but it was too large PR. This is the smaller slice, and only the Brakeman::Runner actually gets to take advantage of it immediately. 

In this step, we extract a BaseRunner, and a set of shared examples for it, and then rewrite the Brakeman::Runner in terms of that BaseRunner. The BaseRunner does not care about `changed_files` or `file_filter`, because it doesn't do any target-selection inherently. It expects to be supplied with a command to run by its subclass, and it _runs that command_.

In this PR, it doesn't actually look like an improvement - we're adding way more code than we're dropping. But in the next slice we'll make up for it! And even then, the shared examples for BaseRunner are not currently a net gain - we're adding them because they will help any time we need to add a runner like Brakeman::Runner, that doesn't do any relevance-management of targets, and we want adding tools to be as easy as possible.

I did originally intend to keep the tool implementations as isolated as possible, and this reverses that course _quite hard_. But the prior implementations would actually all still work - new tools can very well still be written that way. Since we're the ones actually _implementing a bunch of tools_ right now though, I decided it was worth it to make it easy for ourselves :-)

Slice one of #81 