### PR TITLE
Extract the RelevantRunner

### DIFF
--- a/lib/quiet_quality/tools.rb
+++ b/lib/quiet_quality/tools.rb
@@ -9,6 +9,7 @@ module QuietQuality
 end
 
 require_relative "./tools/base_runner"
+require_relative "./tools/relevant_runner"
 
 glob = File.expand_path("../tools/*.rb", __FILE__)
 Dir.glob(glob).sort.each { |f| require f }

--- a/lib/quiet_quality/tools/haml_lint/runner.rb
+++ b/lib/quiet_quality/tools/haml_lint/runner.rb
@@ -1,64 +1,29 @@
 module QuietQuality
   module Tools
     module HamlLint
-      class Runner
-        MAX_FILES = 100
-        NO_FILES_OUTPUT = %({"files": []})
+      class Runner < RelevantRunner
+        def tool_name
+          :haml_lint
+        end
+
+        def no_files_output
+          %({"files": []})
+        end
+
+        def base_command
+          ["haml-lint", "--reporter", "json"]
+        end
+
+        def relevant_path?(path)
+          path.end_with?(".haml")
+        end
 
         # haml-lint uses the `sysexits` gem, and exits with Sysexits::EX_DATAERR for the
         # failures case here in lib/haml_lint/cli.rb. That's mapped to status 65 - other
         # statuses have other failure meanings, which we don't want to interpret as "problems
         # encountered"
-        FAILURE_STATUS = 65
-
-        def initialize(changed_files: nil, file_filter: nil)
-          @changed_files = changed_files
-          @file_filter = file_filter
-        end
-
-        def invoke!
-          @_outcome ||= skip_execution? ? skipped_outcome : performed_outcome
-        end
-
-        private
-
-        attr_reader :changed_files, :file_filter
-
-        def skip_execution?
-          changed_files && relevant_files.empty?
-        end
-
-        def relevant_files
-          return nil if changed_files.nil?
-          changed_files.paths
-            .select { |path| path.end_with?(".haml") }
-            .select { |path| file_filter.nil? || file_filter.match?(path) }
-        end
-
-        def target_files
-          return [] if changed_files.nil?
-          return [] if relevant_files.length > MAX_FILES
-          relevant_files
-        end
-
-        def command
-          return nil if skip_execution?
-          ["haml-lint", "--reporter", "json"] + target_files.sort
-        end
-
-        def skipped_outcome
-          Outcome.new(tool: :haml_lint, output: NO_FILES_OUTPUT)
-        end
-
-        def performed_outcome
-          out, err, stat = Open3.capture3(*command)
-          if stat.success?
-            Outcome.new(tool: :haml_lint, output: out, logging: err)
-          elsif stat.exitstatus == FAILURE_STATUS
-            Outcome.new(tool: :haml_lint, output: out, logging: err, failure: true)
-          else
-            fail(ExecutionError, "Execution of haml-lint failed with #{stat.exitstatus}")
-          end
+        def failure_status?(stat)
+          stat.exitstatus == 65
         end
       end
     end

--- a/lib/quiet_quality/tools/markdown_lint/runner.rb
+++ b/lib/quiet_quality/tools/markdown_lint/runner.rb
@@ -1,60 +1,26 @@
 module QuietQuality
   module Tools
     module MarkdownLint
-      class Runner
-        MAX_FILES = 100
-        NO_FILES_OUTPUT = "[]"
-        FAILURE_STATUS = 1
-
-        def initialize(changed_files: nil, file_filter: nil)
-          @changed_files = changed_files
-          @file_filter = file_filter
+      class Runner < RelevantRunner
+        def tool_name
+          :markdown_lint
         end
 
-        def invoke!
-          @_outcome ||= skip_execution? ? skipped_outcome : performed_outcome
-        end
-
-        private
-
-        attr_reader :changed_files, :file_filter
-
-        def skip_execution?
-          changed_files && relevant_files.empty?
-        end
-
-        def relevant_files
-          return nil if changed_files.nil?
-          changed_files.paths
-            .select { |path| path.end_with?(".md") }
-            .select { |path| file_filter.nil? || file_filter.match?(path) }
-        end
-
-        def target_files
-          return ["."] if changed_files.nil?
-          return ["."] if relevant_files.length > MAX_FILES
-          return ["."] if relevant_files.empty?
-          relevant_files
+        def no_files_output
+          "[]"
         end
 
         def command
           return nil if skip_execution?
-          ["mdl", "--json"] + target_files.sort
-        end
-
-        def skipped_outcome
-          Outcome.new(tool: :markdown_lint, output: NO_FILES_OUTPUT)
-        end
-
-        def performed_outcome
-          out, err, stat = Open3.capture3(*command)
-          if stat.success?
-            Outcome.new(tool: :markdown_lint, output: out, logging: err)
-          elsif stat.exitstatus == FAILURE_STATUS
-            Outcome.new(tool: :markdown_lint, output: out, logging: err, failure: true)
+          if target_files.any?
+            ["mdl", "--json"] + target_files.sort
           else
-            fail(ExecutionError, "Execution of mdl failed with #{stat.exitstatus}")
+            ["mdl", "--json", "."]
           end
+        end
+
+        def relevant_path?(path)
+          path.end_with?(".md")
         end
       end
     end

--- a/lib/quiet_quality/tools/relevant_runner.rb
+++ b/lib/quiet_quality/tools/relevant_runner.rb
@@ -1,0 +1,55 @@
+require_relative "./base_runner"
+
+module QuietQuality
+  module Tools
+    class RelevantRunner < BaseRunner
+      # In general, we don't want to supply a huge number of arguments to a command-line tool.
+      # This will probably become configurable later.
+      MAX_FILES = 100
+
+      def invoke!
+        @_outcome ||= skip_execution? ? skipped_outcome : performed_outcome
+      end
+
+      def command
+        return nil if skip_execution?
+        base_command + target_files.sort
+      end
+
+      def relevant_path?(path)
+        fail(NoMethodError, "RelevantRunner subclass must implement `relevant_path?`")
+      end
+
+      def base_command
+        fail(NoMethodError, "RelevantRunner subclass must implement either `command` or `base_command`")
+      end
+
+      def no_files_output
+        fail(NoMethodError, "RelevantRunner subclass must implement `no_files_output`")
+      end
+
+      private
+
+      def skip_execution?
+        changed_files && relevant_files.empty?
+      end
+
+      def relevant_files
+        return nil if changed_files.nil?
+        changed_files.paths
+          .select { |path| relevant_path?(path) }
+          .select { |path| file_filter.nil? || file_filter.match?(path) }
+      end
+
+      def target_files
+        return [] if changed_files.nil?
+        return [] if relevant_files.length > MAX_FILES
+        relevant_files
+      end
+
+      def skipped_outcome
+        Outcome.new(tool: tool_name, output: no_files_output)
+      end
+    end
+  end
+end

--- a/lib/quiet_quality/tools/rspec/runner.rb
+++ b/lib/quiet_quality/tools/rspec/runner.rb
@@ -1,58 +1,21 @@
 module QuietQuality
   module Tools
     module Rspec
-      class Runner
-        MAX_FILES = 100
-        NO_FILES_OUTPUT = '{"examples": [], "summary": {"failure_count": 0}}'
-
-        def initialize(changed_files: nil, file_filter: nil)
-          @changed_files = changed_files
-          @file_filter = file_filter
+      class Runner < RelevantRunner
+        def tool_name
+          :rspec
         end
 
-        def invoke!
-          @_outcome ||= skip_execution? ? skipped_outcome : performed_outcome
+        def no_files_output
+          '{"examples": [], "summary": {"failure_count": 0}}'
         end
 
-        private
-
-        attr_reader :changed_files, :file_filter
-
-        def skip_execution?
-          changed_files && relevant_files.empty?
+        def base_command
+          ["rspec", "-f", "json"]
         end
 
-        def relevant_files
-          return nil if changed_files.nil?
-          changed_files.paths
-            .select { |path| path.end_with?("_spec.rb") }
-            .select { |path| file_filter.nil? || file_filter.match?(path) }
-        end
-
-        def target_files
-          return [] if changed_files.nil?
-          return [] if relevant_files.length > MAX_FILES
-          relevant_files
-        end
-
-        def command
-          return nil if skip_execution?
-          ["rspec", "-f", "json"] + target_files.sort
-        end
-
-        def skipped_outcome
-          Outcome.new(tool: :rspec, output: NO_FILES_OUTPUT)
-        end
-
-        def performed_outcome
-          out, err, stat = Open3.capture3(*command)
-          if stat.success?
-            Outcome.new(tool: :rspec, output: out, logging: err)
-          elsif stat.exitstatus == 1
-            Outcome.new(tool: :rspec, output: out, logging: err, failure: true)
-          else
-            fail(ExecutionError, "Execution of rspec failed with #{stat.exitstatus}")
-          end
+        def relevant_path?(path)
+          path.end_with?("_spec.rb")
         end
       end
     end

--- a/lib/quiet_quality/tools/rubocop/runner.rb
+++ b/lib/quiet_quality/tools/rubocop/runner.rb
@@ -1,68 +1,21 @@
 module QuietQuality
   module Tools
     module Rubocop
-      class Runner
-        MAX_FILES = 100
-        NO_FILES_OUTPUT = '{"files": [], "summary": {"offense_count": 0}}'
-
-        def command_name
-          "rubocop"
+      class Runner < RelevantRunner
+        def tool_name
+          :rubocop
         end
 
-        # Supplying changed_files: nil means "run against all files".
-        def initialize(changed_files: nil, file_filter: nil)
-          @changed_files = changed_files
-          @file_filter = file_filter
+        def no_files_output
+          '{"files": [], "summary": {"offense_count": 0}}'
         end
 
-        def invoke!
-          @_outcome ||= skip_execution? ? skipped_outcome : performed_outcome
+        def base_command
+          ["rubocop", "-f", "json"]
         end
 
-        private
-
-        attr_reader :changed_files, :file_filter
-
-        # If we were told that _no files changed_ (which is distinct from not being told that
-        # any files changed - a [] instead of a nil), then we shouldn't run rubocop at all.
-        def skip_execution?
-          changed_files && relevant_files.empty?
-        end
-
-        # Note: if target_files goes over MAX_FILES, it's _empty_ instead - that means that
-        # we run against the full repository instead of the specific files (rubocop's behavior
-        # when no target files are specified)
-        def command
-          return nil if skip_execution?
-          [command_name, "-f", "json"] + target_files.sort
-        end
-
-        def relevant_files
-          return nil if changed_files.nil?
-          changed_files.paths
-            .select { |path| path.end_with?(".rb") }
-            .select { |path| file_filter.nil? || file_filter.match?(path) }
-        end
-
-        def target_files
-          return [] if changed_files.nil?
-          return [] if relevant_files.length > MAX_FILES
-          relevant_files
-        end
-
-        def skipped_outcome
-          Outcome.new(tool: command_name.to_sym, output: NO_FILES_OUTPUT)
-        end
-
-        def performed_outcome
-          out, err, stat = Open3.capture3(*command)
-          if stat.success?
-            Outcome.new(tool: command_name.to_sym, output: out, logging: err)
-          elsif stat.exitstatus == 1
-            Outcome.new(tool: command_name.to_sym, output: out, logging: err, failure: true)
-          else
-            fail(ExecutionError, "Execution of #{command_name} failed with #{stat.exitstatus}")
-          end
+        def relevant_path?(path)
+          path.end_with?(".rb")
         end
       end
     end

--- a/lib/quiet_quality/tools/standardrb/runner.rb
+++ b/lib/quiet_quality/tools/standardrb/runner.rb
@@ -1,9 +1,21 @@
 module QuietQuality
   module Tools
     module Standardrb
-      class Runner < Rubocop::Runner
-        def command_name
-          "standardrb"
+      class Runner < RelevantRunner
+        def tool_name
+          :standardrb
+        end
+
+        def no_files_output
+          '{"files": [], "summary": {"offense_count": 0}}'
+        end
+
+        def base_command
+          ["standardrb", "-f", "json"]
+        end
+
+        def relevant_path?(path)
+          path.end_with?(".rb")
         end
       end
     end

--- a/spec/quiet_quality/tools/relevant_runner_spec.rb
+++ b/spec/quiet_quality/tools/relevant_runner_spec.rb
@@ -1,0 +1,150 @@
+RSpec.describe QuietQuality::Tools::RelevantRunner do
+  let(:changed_files) { nil }
+  let(:file_filter) { /\.rb$/ }
+  subject(:runner) { subclass.new(changed_files: changed_files, file_filter: file_filter) }
+
+  context "with an improperly implemented subclass" do
+    let(:subclass) { Class.new(described_class) }
+
+    describe "#invoke!" do
+      subject(:invoke!) { runner.invoke! }
+
+      it "raises a NoMethodError" do
+        expect { invoke! }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "#command" do
+      subject(:command) { runner.command }
+
+      it "raises a NoMethodError" do
+        expect { command }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "#relevant_path?" do
+      let(:path) { "fake/path" }
+      subject(:relevant_path?) { runner.relevant_path?(path) }
+
+      it "raises a NoMethodError" do
+        expect { relevant_path? }
+          .to raise_error(NoMethodError, /RelevantRunner subclass must.*relevant_path/)
+      end
+    end
+
+    describe "#base_command" do
+      subject(:base_command) { runner.base_command }
+
+      it "raises a NoMethodError" do
+        expect { base_command }
+          .to raise_error(NoMethodError, /RelevantRunner subclass must.*command.*base_command/)
+      end
+    end
+
+    describe "#no_files_output" do
+      subject(:no_files_output) { runner.no_files_output }
+
+      it "raises a NoMethodError" do
+        expect { no_files_output }
+          .to raise_error(NoMethodError, /RelevantRunner subclass must.*no_files_output/)
+      end
+    end
+  end
+
+  context "with a properly implemented subclass" do
+    let(:subclass) do
+      Class.new(described_class) do
+        def tool_name
+          :fake_tool
+        end
+
+        def relevant_path?(path)
+          path.include?("foo")
+        end
+
+        def base_command
+          ["fake", "command"]
+        end
+
+        def no_files_output
+          "no files"
+        end
+      end
+    end
+
+    describe "#command" do
+      subject(:command) { runner.command }
+
+      context "when there are no changes to consider" do
+        let(:changed_files) { nil }
+        it { is_expected.to eq(["fake", "command"]) }
+      end
+
+      context "when there are changes to consider" do
+        context "but they are empty" do
+          let(:changed_files) { empty_changed_files }
+          it { is_expected.to be_nil }
+        end
+
+        context "but they contain no files matching the relevance method and file_filter" do
+          let(:changed_files) { fully_changed_files("baz.rb", "zum", "zim.rb", "zam") }
+          it { is_expected.to be_nil }
+        end
+
+        context "and they contain some files that are relevant" do
+          let(:changed_files) { fully_changed_files("baz", "foobar.rb", "zim", "foo.rb") }
+          it { is_expected.to eq(["fake", "command", "foo.rb", "foobar.rb"]) }
+        end
+      end
+    end
+
+    describe "#invoke!" do
+      subject(:invoke!) { runner.invoke!}
+
+      let(:out) { "fake stdout" }
+      let(:err) { "fake stderr" }
+      let(:stat) { mock_status(0) }
+      before { allow(Open3).to receive(:capture3).and_return([out, err, stat]) }
+
+      shared_examples "exposes the successful command output" do
+        it { is_expected.to eq(build_success(:fake_tool, out, err)) }
+
+        it "invokes the tool with the command" do
+          invoke!
+          expect(Open3).to have_received(:capture3).with(*runner.command)
+        end
+      end
+
+      shared_examples "skips the command and succeeds immediately" do
+        it { is_expected.to eq(build_success(:fake_tool, runner.no_files_output)) }
+
+        it "invokes the tool with the command" do
+          invoke!
+          expect(Open3).not_to have_received(:capture3)
+        end
+      end
+
+      context "when there are no changes to consider" do
+        let(:changed_files) { nil }
+        include_examples "exposes the successful command output"
+      end
+
+      context "when there are changes to consider" do
+        context "but they are empty" do
+          let(:changed_files) { empty_changed_files }
+          include_examples "skips the command and succeeds immediately"
+        end
+
+        context "but they contain no files matching the relevance method and file_filter" do
+          let(:changed_files) { fully_changed_files("baz.rb", "zum", "zim.rb", "zam") }
+          include_examples "skips the command and succeeds immediately"
+        end
+
+        context "and they contain some files that are relevant" do
+          let(:changed_files) { fully_changed_files("baz", "foobar.rb", "zim", "foo.rb") }
+          include_examples "exposes the successful command output"
+        end
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/tools/relevant_runner_spec.rb
+++ b/spec/quiet_quality/tools/relevant_runner_spec.rb
@@ -1,3 +1,5 @@
+require_relative "./runner_examples"
+
 RSpec.describe QuietQuality::Tools::RelevantRunner do
   let(:changed_files) { nil }
   let(:file_filter) { /\.rb$/ }
@@ -99,7 +101,7 @@ RSpec.describe QuietQuality::Tools::RelevantRunner do
     end
 
     describe "#invoke!" do
-      subject(:invoke!) { runner.invoke!}
+      subject(:invoke!) { runner.invoke! }
 
       let(:out) { "fake stdout" }
       let(:err) { "fake stderr" }
@@ -146,5 +148,13 @@ RSpec.describe QuietQuality::Tools::RelevantRunner do
         end
       end
     end
+
+    it_behaves_like "a functional RelevantRunner subclass", :fake_tool, {
+      runner_class_method: :subclass,
+      relevant: "foo.rb",
+      irrelevant: "bar.rb",
+      filter: /\.rb/,
+      base_command: ["fake", "command"]
+    }
   end
 end

--- a/spec/quiet_quality/tools/rspec/runner_spec.rb
+++ b/spec/quiet_quality/tools/rspec/runner_spec.rb
@@ -1,100 +1,58 @@
+require_relative "../runner_examples"
+
 RSpec.describe QuietQuality::Tools::Rspec::Runner do
   let(:changed_files) { nil }
   let(:file_filter) { nil }
   subject(:runner) { described_class.new(changed_files: changed_files, file_filter: file_filter) }
 
-  let(:out) { "fake output" }
-  let(:err) { "fake error" }
-  let(:stat) { instance_double(Process::Status, success?: true, exitstatus: 0) }
-  before { allow(Open3).to receive(:capture3).and_return([out, err, stat]) }
+  it_behaves_like "a functional RelevantRunner subclass", :rspec, {
+    relevant: "foo_spec.rb",
+    irrelevant: "bar.ts",
+    filter: /\.rb/,
+    base_command: ["rspec", "-f", "json"]
+  }
 
-  describe "#invoke!" do
-    subject(:invoke!) { runner.invoke! }
+  describe "#tool_name" do
+    subject(:tool_name) { runner.tool_name }
+    it { is_expected.to eq(:rspec) }
+  end
 
-    context "when the rspec command fails" do
-      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
+  describe "#no_files_output" do
+    subject { runner.no_files_output }
+    let(:parsed) { JSON.parse(subject) }
 
-      it "raises an ExecutionError" do
-        expect { invoke! }.to raise_error(QuietQuality::Tools::ExecutionError)
-      end
+    it "contains the expected data" do
+      expect(parsed.dig("examples")).to eq([])
+      expect(parsed.dig("summary", "failure_count")).to eq(0)
+    end
+  end
+
+  describe "#base_command" do
+    subject(:base_command) { runner.base_command }
+    it { is_expected.to eq(["rspec", "-f", "json"]) }
+  end
+
+  describe "#relevant_path?" do
+    subject(:relevant_path?) { runner.relevant_path?(path) }
+
+    context "for a random other file" do
+      let(:path) { "foo/bar.ts" }
+      it { is_expected.to be_falsey }
     end
 
-    context "when the rspec _tests_ fail" do
-      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 1) }
-      it { is_expected.to eq(build_failure(:rspec, "fake output", "fake error")) }
-
-      it "calls rspec with no targets" do
-        invoke!
-        expect(Open3)
-          .to have_received(:capture3)
-          .with("rspec", "-f", "json")
-      end
+    context "for a non-spec ruby file" do
+      let(:path) { "foo/bar.rb" }
+      it { is_expected.to be_falsey }
     end
 
-    context "when changed_files is nil" do
-      let(:changed_files) { nil }
-      it { is_expected.to eq(build_success(:rspec, "fake output", "fake error")) }
-
-      it "calls rspec with no targets" do
-        invoke!
-        expect(Open3)
-          .to have_received(:capture3)
-          .with("rspec", "-f", "json")
-      end
+    context "for a ruby spec file" do
+      let(:path) { "foo/bar_spec.rb" }
+      it { is_expected.to be_truthy }
     end
 
-    context "when changed_files is empty" do
-      let(:changed_files) { empty_changed_files }
-      it { is_expected.to eq(build_success(:rspec, described_class::NO_FILES_OUTPUT)) }
-
-      it "does not call rspec" do
-        expect(Open3).not_to have_received(:capture3)
-      end
-    end
-
-    context "when changed_files is full" do
-      context "but contains no spec files" do
-        let(:changed_files) { generate_changed_files({"foo_spec.ts" => :all, "bar.rb" => [1, 2], "baz_spec.rb.bak" => [5]}) }
-        it { is_expected.to eq(build_success(:rspec, described_class::NO_FILES_OUTPUT)) }
-
-        it "does not call rspec" do
-          expect(Open3).not_to have_received(:capture3)
-        end
-      end
-
-      context "and contains some spec files" do
-        let(:changed_paths) { ["foo_spec.ts", "bar_spec.rb", "baz_spec.rb.bak", "a/alpha_spec.rb"] }
-        let(:changed_files) { generate_changed_files(changed_paths.map { |p| [p, :all] }.to_h) }
-        it { is_expected.to eq(build_success(:rspec, "fake output", "fake error")) }
-
-        it "calls rspec with the correct targets" do
-          invoke!
-          expect(Open3)
-            .to have_received(:capture3)
-            .with("rspec", "-f", "json", "a/alpha_spec.rb", "bar_spec.rb")
-        end
-
-        context "but some of them are filtered out" do
-          let(:file_filter) { /pha/ }
-          it { is_expected.to eq(build_success(:rspec, "fake output", "fake error")) }
-
-          it "calls rspec with the correct target" do
-            invoke!
-            expect(Open3)
-              .to have_received(:capture3)
-              .with("rspec", "-f", "json", "a/alpha_spec.rb")
-          end
-        end
-
-        context "but all of them are filtered out" do
-          let(:file_filter) { /nobody/ }
-          it { is_expected.to eq(build_success(:rspec, described_class::NO_FILES_OUTPUT)) }
-
-          it "does not call rspec" do
-            expect(Open3).not_to have_received(:capture3)
-          end
-        end
-      end
+    context "for a weirdly named, but non-spec file" do
+      let(:path) { "foo/bar_spec.rb.txt" }
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/spec/quiet_quality/tools/runner_examples.rb
+++ b/spec/quiet_quality/tools/runner_examples.rb
@@ -1,4 +1,5 @@
-shared_examples "a functional BaseRunner subclass" do |tool_name, opts|
+shared_examples "a functional BaseRunner subclass" do |tool_name, options|
+  opts = options || {}
   success_statuses = opts.fetch(:success, [0])
   failure_statuses = opts.fetch(:failure, [1])
   error_statuses = opts.fetch(:error, [99])
@@ -20,6 +21,173 @@ shared_examples "a functional BaseRunner subclass" do |tool_name, opts|
 
   describe "#invoke!" do
     subject(:invoke!) { runner.invoke! }
+
+    success_statuses.each do |success_status|
+      context "with a (successful) exit status of #{success_status}" do
+        let(:stat) { mock_status(success_status) }
+        it { is_expected.to eq(build_outcome(tool: runner.tool_name, output: out, logging: err, failure: false)) }
+      end
+    end
+
+    failure_statuses.each do |failure_status|
+      context "with a (failing) exit status of #{failure_status}" do
+        let(:stat) { mock_status(failure_status) }
+        it { is_expected.to eq(build_outcome(tool: runner.tool_name, output: out, logging: err, failure: true)) }
+      end
+    end
+
+    error_statuses.each do |error_status|
+      context "with an (unexpected) exit status of #{error_status}" do
+        let(:stat) { mock_status(error_status) }
+
+        it "raises an ExecutionError" do
+          expect { invoke! }.to raise_error(
+            QuietQuality::Tools::ExecutionError,
+            /Execution of #{runner.tool_name} failed with #{error_status}/
+          )
+        end
+      end
+    end
+  end
+end
+
+shared_examples "a functional RelevantRunner subclass" do |tool_name, options|
+  opts = options || {}
+  success_statuses = opts.fetch(:success, [0])
+  failure_statuses = opts.fetch(:failure, [1])
+  error_statuses = opts.fetch(:error, [99])
+  relevant_name = opts.fetch(:relevant)
+  irrelevant_name = opts.fetch(:irrelevant)
+  filter = opts.fetch(:filter)
+  base_command = opts.fetch(:base_command, nil)
+
+  if opts[:runner_class_method]
+    let(:runner_class) { send opts[:runner_class_method] }
+  else
+    let(:runner_class) { described_class }
+  end
+
+  let(:changed_files) { nil }
+  let(:file_filter) { filter }
+  let(:runner) { runner_class.new(changed_files: changed_files, file_filter: file_filter) }
+
+  describe "#tool_name" do
+    subject { runner.tool_name }
+    it { is_expected.to be_a(Symbol) }
+    it { is_expected.to eq(tool_name) }
+  end
+
+  describe "#relevant_path?" do
+    subject(:relevant_path?) { runner.relevant_path?("/fake/path") }
+
+    it "doesn't raise an error" do
+      expect { relevant_path? }.not_to raise_error
+    end
+  end
+
+  describe "#no_files_output" do
+    subject(:no_files_output) { runner.no_files_output }
+    it { is_expected.to be_a(String) }
+  end
+
+  describe "#command" do
+    subject(:command) { runner.command }
+
+    if base_command
+      context "when there are no changes to consider" do
+        let(:changed_files) { nil }
+        it { is_expected.to eq(base_command) }
+      end
+
+      context "when there are changes to consider" do
+        context "but they are empty" do
+          let(:changed_files) { empty_changed_files }
+          it { is_expected.to be_nil }
+        end
+
+        context "but they contain no files matching the relevance method" do
+          let(:changed_files) { fully_changed_files(irrelevant_name) }
+          it { is_expected.to be_nil }
+        end
+
+        context "and they contain some files that are relevant" do
+          let(:changed_files) { fully_changed_files(relevant_name, irrelevant_name) }
+
+          context "but none matching the file_filter" do
+            let(:file_filter) { /never_gonna_give_you_up/ }
+            it { is_expected.to be_nil }
+          end
+
+          context "and they also match the file_filter" do
+            let(:file_filter) { /./ }
+            it { is_expected.to eq(base_command + [relevant_name]) }
+
+            context "but there are _too many_ of them" do
+              before { stub_const("QuietQuality::Tools::RelevantRunner::MAX_FILES", 0) }
+              it { is_expected.to eq(base_command) }
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "#invoke!" do
+    subject(:invoke!) { runner.invoke! }
+
+    let(:out) { "fake stdout" }
+    let(:err) { "fake stderr" }
+    let(:stat) { mock_status(0) }
+    before { allow(Open3).to receive(:capture3).and_return([out, err, stat]) }
+
+    shared_examples "exposes the successful command output" do
+      it { is_expected.to eq(build_success(tool_name, out, err)) }
+
+      it "invokes the tool with the command" do
+        invoke!
+        expect(Open3).to have_received(:capture3).with(*runner.command)
+      end
+    end
+
+    shared_examples "skips the command and succeeds immediately" do
+      it { is_expected.to eq(build_success(tool_name, runner.no_files_output)) }
+
+      it "invokes the tool with the command" do
+        invoke!
+        expect(Open3).not_to have_received(:capture3)
+      end
+    end
+
+    context "when there are no changes to consider" do
+      let(:changed_files) { nil }
+      include_examples "exposes the successful command output"
+    end
+
+    context "when there are changes to consider" do
+      context "but they are empty" do
+        let(:changed_files) { empty_changed_files }
+        include_examples "skips the command and succeeds immediately"
+      end
+
+      context "but they contain no files matching the relevance method" do
+        let(:changed_files) { fully_changed_files(irrelevant_name) }
+        include_examples "skips the command and succeeds immediately"
+      end
+
+      context "and they contain some files that are relevant" do
+        let(:changed_files) { fully_changed_files(relevant_name, irrelevant_name) }
+
+        context "but none matching the file_filter" do
+          let(:file_filter) { /never_gonna_let_you_down/ }
+          include_examples "skips the command and succeeds immediately"
+        end
+
+        context "and they also match the file_filter" do
+          let(:file_filter) { /./ }
+          include_examples "exposes the successful command output"
+        end
+      end
+    end
 
     success_statuses.each do |success_status|
       context "with a (successful) exit status of #{success_status}" do

--- a/spec/quiet_quality/tools/runner_examples.rb
+++ b/spec/quiet_quality/tools/runner_examples.rb
@@ -59,7 +59,7 @@ shared_examples "a functional RelevantRunner subclass" do |tool_name, options|
   relevant_name = opts.fetch(:relevant)
   irrelevant_name = opts.fetch(:irrelevant)
   filter = opts.fetch(:filter)
-  base_command = opts.fetch(:base_command, nil)
+  base_command = opts.fetch(:base_command)
 
   if opts[:runner_class_method]
     let(:runner_class) { send opts[:runner_class_method] }
@@ -93,7 +93,7 @@ shared_examples "a functional RelevantRunner subclass" do |tool_name, options|
   describe "#command" do
     subject(:command) { runner.command }
 
-    if base_command
+    if base_command != :skip
       context "when there are no changes to consider" do
         let(:changed_files) { nil }
         it { is_expected.to eq(base_command) }

--- a/spec/quiet_quality/tools/standardrb/runner_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/runner_spec.rb
@@ -1,117 +1,53 @@
+require_relative "../runner_examples"
+
 RSpec.describe QuietQuality::Tools::Standardrb::Runner do
   let(:changed_files) { nil }
   let(:file_filter) { nil }
   subject(:runner) { described_class.new(changed_files: changed_files, file_filter: file_filter) }
 
-  let(:out) { "fake output" }
-  let(:err) { "fake error" }
-  let(:stat) { instance_double(Process::Status, success?: true, exitstatus: 0) }
-  before { allow(Open3).to receive(:capture3).and_return([out, err, stat]) }
+  it_behaves_like "a functional RelevantRunner subclass", :standardrb, {
+    relevant: "foo.rb",
+    irrelevant: "foo.ts",
+    filter: /foo/,
+    base_command: ["standardrb", "-f", "json"]
+  }
 
-  describe "#invoke!" do
-    subject(:invoke!) { runner.invoke! }
+  describe "#tool_name" do
+    subject(:tool_name) { runner.tool_name }
+    it { is_expected.to eq(:standardrb) }
+  end
 
-    context "when the standardrb command _fails_" do
-      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 14) }
+  describe "#no_files_output" do
+    subject { runner.no_files_output }
+    let(:parsed) { JSON.parse(subject) }
 
-      it "raises an ExecutionError" do
-        expect { invoke! }.to raise_error(QuietQuality::Tools::ExecutionError)
-      end
+    it "contains the expected data" do
+      expect(parsed.dig("files")).to eq([])
+      expect(parsed.dig("summary", "offense_count")).to eq(0)
+    end
+  end
+
+  describe "#base_command" do
+    subject(:base_command) { runner.base_command }
+    it { is_expected.to eq(["standardrb", "-f", "json"]) }
+  end
+
+  describe "#relevant_path?" do
+    subject(:relevant_path?) { runner.relevant_path?(path) }
+
+    context "for a random other file" do
+      let(:path) { "foo/bar.ts" }
+      it { is_expected.to be_falsey }
     end
 
-    context "when the standardrb command _finds problems_" do
-      let(:stat) { instance_double(Process::Status, success?: false, exitstatus: 1) }
-      it { is_expected.to eq(build_failure(:standardrb, "fake output", "fake error")) }
-
-      it "calls standardrb correctly, with no targets" do
-        invoke!
-        expect(Open3).to have_received(:capture3).with("standardrb", "-f", "json")
-      end
+    context "for a ruby file" do
+      let(:path) { "foo/bar.rb" }
+      it { is_expected.to be_truthy }
     end
 
-    context "when changed_files is nil" do
-      let(:changed_files) { nil }
-      it { is_expected.to eq(build_success(:standardrb, "fake output", "fake error")) }
-
-      it "calls standardrb correctly, with no targets" do
-        invoke!
-        expect(Open3)
-          .to have_received(:capture3)
-          .with("standardrb", "-f", "json")
-      end
-    end
-
-    context "when changed_files is empty" do
-      let(:changed_files) { empty_changed_files }
-      it { is_expected.to eq(build_success(:standardrb, described_class::NO_FILES_OUTPUT)) }
-
-      it "does not call standardrb" do
-        invoke!
-        expect(Open3).not_to have_received(:capture3)
-      end
-    end
-
-    context "when changed_files is full" do
-      let(:file1) { "foo.js" }
-      let(:file2) { "bar.rb" }
-      let(:file3) { "baz.rb" }
-      let(:changed_files) { fully_changed_files(file1, file2, file3) }
-
-      context "but contains no ruby files" do
-        let(:file2) { "bar.js" }
-        let(:file3) { "baz.ts" }
-        it { is_expected.to eq(build_success(:standardrb, described_class::NO_FILES_OUTPUT)) }
-
-        it "does not call standardrb" do
-          invoke!
-          expect(Open3).not_to have_received(:capture3)
-        end
-      end
-
-      context "and contains some ruby files" do
-        it { is_expected.to eq(build_success(:standardrb, "fake output", "fake error")) }
-
-        it "calls standardrb correctly, with changed and relevant targets" do
-          invoke!
-          expect(Open3)
-            .to have_received(:capture3)
-            .with("standardrb", "-f", "json", "bar.rb", "baz.rb")
-        end
-
-        context "but some of them are filtered out" do
-          let(:file_filter) { /bar/ }
-          it { is_expected.to eq(build_success(:standardrb, "fake output", "fake error")) }
-
-          it "calls standardrb correctly, with changed and relevant targets" do
-            invoke!
-            expect(Open3)
-              .to have_received(:capture3)
-              .with("standardrb", "-f", "json", "bar.rb")
-          end
-        end
-
-        context "but all of them are filtered out" do
-          let(:file_filter) { /nobody/ }
-          it { is_expected.to eq(build_success(:standardrb, described_class::NO_FILES_OUTPUT)) }
-
-          it "does not call standardrb" do
-            invoke!
-            expect(Open3).not_to have_received(:capture3)
-          end
-        end
-      end
-
-      context "and contains too many ruby files" do
-        before { stub_const("QuietQuality::Tools::Rubocop::Runner::MAX_FILES", 1) }
-        it { is_expected.to eq(build_success(:standardrb, "fake output", "fake error")) }
-
-        it "calls standardrb correctly, with no targets" do
-          invoke!
-          expect(Open3)
-            .to have_received(:capture3)
-            .with("standardrb", "-f", "json")
-        end
-      end
+    context "for a weirdly named, but non-ruby file" do
+      let(:path) { "foo/bar.rb.txt" }
+      it { is_expected.to be_falsey }
     end
   end
 end


### PR DESCRIPTION
This one is the meatier second slice of #81 - the rest of the existing tools _all_ share the bulk of this code (the markdown-linter has a minor difference that leads to our need to allow `command` to be overridden instead of `base_command` as necessary).

The RelevantRunner inherits from BaseRunner to handle the execution of the command. But it knows how to use ChangedFiles to determine the _relevant_ files, distill those into the _target_ files (based on limits and presences), and construct the real command given a base_command. It's also aware that, if it knows about changes, but there aren't any relevant ones, it can skip the execution.

It expects the subclass to provide a few things - `tool_name` of course, but also `no_files_output` (what to produce if skipping execution), either `base_command` or `command` (in the usual case, we supply no arguments to run against the whole project, and some arguments to only run against those files. But in some cases that's not accurate, and `command` itself needs to be overridden), and `relevant_path?(path)`, which defines what files this tool actually cares about.

This is a net wash, total-code-wise, because I chose to leave the specs for the BaseRunner and RelevantRunner in place despite running an essentially similar set of tests through the shared examples. I regard that as a form of validation though, as the shared examples themselves are _fairly complex code_. At any rate, the process of writing a new tool now takes roughly a third as much code (and it's largely trivial), which was the real goal.


_Definitely_ review this PR by commit - the majority of the changes are very similar transformations, rewriting each runner one at a time in terms of the RelevantRunner.

Resolves #81 