### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+## Release 1.2.0
+
+* Support `--light`, `--quiet`, and `--logging LEVEL` arguments for less output
+  (#78, resolves #37)
+* Support the [markdownlint](https://github.com/markdownlint/markdownlint) tool
+  (#79, resolves #58)
+* Extract BaseRunner (#82) and RelevantRunner (#83) parent classes from the tool
+  runners, to allow new tools to be more easily implemented. (Resolves #81)
+* Extract a Cli::Presenter from the Entrypoint, to simplify pending work on cli
+  presentation (#84, resolves #42)
+* Update the docs a bit, and add a changelog (hi!)
+
+## Release 1.1.0
+
+* Support a `file_filter` config entry per-tool (without a cli option), to limit
+  what file paths a runner might supply to its tool based on a regex
+  (#74, resolves #68)
+* When what tools to execute is not specified (by cli or by config file), abort
+  `bin/qq` and explain, rather than assuming "all of them" (#79, resolves #58)
+* Update the config parser to handle keys named to match the cli options
+  alongside the ones that were (mistakenly) named differently. This is a
+  backwards-compatible change; if we eventually deprecate and simplify some of
+  these option names, you'll have plenty of warning (#77, resolves #75)
+* Support `--version/-V` flag (#73, resolves #69)
+
+## Release 1.0.3
+
+* Fix the printed _output_ for the case where there were some warnings from a
+  tool, but all of them were filtered out (because they targetted lines that
+  were not changed, for example). This situation should tell you that nothing
+  is wrong with your PR, not that there is a problem (#71)
+
+## Release 1.0.2
+
+* Fix the _exit status_ for the case where there were some warnings from a
+  tool, but all of them were filtered out (because they targetted lines that
+  were not changed, for example). This situation should produce a successful
+  result, and not fail a CI pipeline (#67)
+
+## Release 1.0.1
+
+* Fix the calculation of `changed_files` for the executor - in the migration
+  to Entrypoint, the actual git call to get a ChangedFiles object to pass into
+  other service classes was lost, which had the result that the entire system
+  behaved (outside of tests) as if you were always running with `--all-files`
+  (#65).
+
+## Release 1.0.0
+
+Initial functional public release.

--- a/README.md
+++ b/README.md
@@ -171,15 +171,32 @@ rspec:
 
 ### CLI Options
 
-The same options are all available on the CLI, plus some additional ones - run
-`qq --help` for a detailed list of the options, but the notable additions are:
+To specify which _tools_ to run (and if any are specified, the `default_tools`
+from the configuration file will be ignored), you supply them as positional
+arguments: `qq rubocop rspec --all-files -L` will run the `rubocop` and `rspec`
+tools, for example.
 
-* `--help/-H`: See a list of the options
-* `--no-config/-N`: Do _not_ load a config file, even if present.
-* `--config/-C`: load the supplied config file (instead of the detected one, if
-  found)
-* `--version/-V`: what version of the gem are you using?
-* `--light/-l`: Enable light logging.
-* `--quiet/-q: Enable quiet logging.
-* `--logging/-L LEVEL: Specify logging mode that results will be returned in.
-  Valid options: light, quiet
+Run `qq --help` for a detailed list of the CLI options, they largely agree with
+those in the configuration file, but there are some differences. There's no way
+to specify a `file_filter` for a tool on the command-line, and there are some
+additional options available focused on managing the interactions with
+configuration files.
+
+```text
+Usage: qq [TOOLS] [GLOBAL_OPTIONS] [TOOL_OPTIONS]
+    -h, --help                       Prints this help
+    -V, --version                    Print the current version of the gem
+    -C, --config PATH                Load a config file from this path
+    -N, --no-config                  Do not load a config file, even if present
+    -E, --executor EXECUTOR          Which executor to use
+    -A, --annotate ANNOTATOR         Annotate with this annotator
+    -G, --annotate-github-stdout     Annotate with GitHub Workflow commands
+    -a, --all-files [tool]           Use the tool(s) on all files
+    -c, --changed-files [tool]       Use the tool(s) only on changed files
+    -B, --comparison-branch BRANCH   Specify the branch to compare against
+    -f, --filter-messages [tool]     Filter messages from tool(s) based on changed lines
+    -u, --unfiltered [tool]          Don't filter messages from tool(s)
+    -l, --light                      Print aggregated results only
+    -q, --quiet                      Don't print results, only return a status code
+    -L, --logging LEVEL              Specify logging mode that results will be returned in. Valid options: light, quiet
+```

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ that too.
 
 So far, we have support for the following tools:
 
-* rubocop
-* standardrb
-* rspec
-* haml-lint
-* brakeman (though there's no way to run this against only changed files)
+* [rubocop](https://github.com/rubocop/rubocop)
+* [standardrb](https://github.com/standardrb/standard)
+* [rspec](https://rspec.info/)
+* [haml-lint](https://github.com/sds/haml-lint)
+* [markdownlint](https://github.com/markdownlint/markdownlint)
+* [brakeman](https://brakemanscanner.org/) (though there's no way to run this
+  against only changed files)
 
 Supporting more tools is relatively straightforward - they're implemented by
 wrapping cli invocations and parsing output files (which overall seem to be much

--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ And then run `qq -C config/quiet_quality/linters_workflow.yml`
 
 The configuration file supports the following _global_ options (top-level keys):
 
+* `default_tools`: Which tools should be run when you `qq` without specifying?
+  Valid values are: `rubocop`, `rspec`, `standardrb`, `haml_lint`, `brakeman`,
+  and `markdown_lint`.
 * `executor`: 'serial' or 'concurrent' (the latter is the default)
 * `annotator`: none set by default, and `github_stdout` is the only supported
   value so far.

--- a/lib/quiet_quality/version.rb
+++ b/lib/quiet_quality/version.rb
@@ -1,3 +1,3 @@
 module QuietQuality
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
* Update the README a bit (reference markdownlint, link the tool origins, and improve the cli docs a lot).
* Add a Changelog file going back to 1.0.0
* Bump to 1.2.0