### PR TITLE
Add coverage checks

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -30,4 +30,4 @@ jobs:
         run: bundle install --jobs 4 --retry 3
 
       - name: Run RSpec
-        run: SIMPLECOV=true bundle exec rspec
+        run: SIMPLECOV=true SIMPLECOV_TEXT=true bundle exec rspec

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -30,4 +30,4 @@ jobs:
         run: bundle install --jobs 4 --retry 3
 
       - name: Run RSpec
-        run: bundle exec rspec
+        run: SIMPLECOV=true bundle exec rspec

--- a/lib/quiet_quality/cli/entrypoint.rb
+++ b/lib/quiet_quality/cli/entrypoint.rb
@@ -62,14 +62,6 @@ module QuietQuality
         parsed_options.helping?
       end
 
-      def quiet_logging?
-        options.logging.quiet?
-      end
-
-      def light_logging?
-        options.logging.light?
-      end
-
       def printing_version?
         parsed_options.printing_version?
       end

--- a/lib/quiet_quality/config/finder.rb
+++ b/lib/quiet_quality/config/finder.rb
@@ -25,10 +25,6 @@ module QuietQuality
 
       attr_reader :from
 
-      def config_path_within(dir)
-        File.join(dir, CONFIG_FILENAME)
-      end
-
       def each_successive_enclosing_directory(max_depth: 100, &block)
         d = Pathname.new(from)
         depth = 0

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -102,8 +102,6 @@ module QuietQuality
         when :reversed_boolean then validate_boolean(name, value)
         when :symbol then validate_symbol(name, value, from: from)
         when :string then validate_string(name, value)
-        else
-          fail ArgumentError, "validate_value does not handle type #{as}"
         end
       end
 
@@ -135,8 +133,6 @@ module QuietQuality
         when :reversed_boolean then !value
         when :string then value.to_s
         when :symbol then value.to_sym
-        else
-          fail ArgumentError, "coerce_value does not handle type #{as}"
         end
       end
     end

--- a/lib/quiet_quality/executors/base_executor.rb
+++ b/lib/quiet_quality/executors/base_executor.rb
@@ -7,7 +7,7 @@ module QuietQuality
       end
 
       def execute!
-        fail NoMethodError, "execute! should be implemented by the subclass of BaseExecutor"
+        pipelines.none?(&:failure?)
       end
 
       def outcomes
@@ -38,16 +38,6 @@ module QuietQuality
         @_pipelines ||= tools.map do |topts|
           Pipeline.new(tool_options: topts, changed_files: changed_files)
         end
-      end
-
-      def pipeline_by_tool
-        @_pipeline_by_tool ||= pipelines
-          .map { |p| [p.tool_name, p] }
-          .to_h
-      end
-
-      def pipeline_for(tool)
-        pipeline_by_tool.fetch(tool.to_sym)
       end
     end
   end

--- a/lib/quiet_quality/version_control_systems/git.rb
+++ b/lib/quiet_quality/version_control_systems/git.rb
@@ -100,10 +100,7 @@ module QuietQuality
 
       def untracked_paths
         out, err, stat = Open3.capture3("git", "-C", path, "ls-files", "--others", "--exclude-standard")
-        unless stat.success?
-          warn err
-          fail(Error, "git ls-files failed")
-        end
+        fail(Error, "git ls-files failed") unless stat.success?
         out.split
       end
     end

--- a/lib/quiet_quality/version_control_systems/git.rb
+++ b/lib/quiet_quality/version_control_systems/git.rb
@@ -99,7 +99,7 @@ module QuietQuality
       end
 
       def untracked_paths
-        out, err, stat = Open3.capture3("git", "-C", path, "ls-files", "--others", "--exclude-standard")
+        out, _err, stat = Open3.capture3("git", "-C", path, "ls-files", "--others", "--exclude-standard")
         fail(Error, "git ls-files failed") unless stat.success?
         out.split
       end

--- a/lib/quiet_quality/version_control_systems/git.rb
+++ b/lib/quiet_quality/version_control_systems/git.rb
@@ -66,12 +66,6 @@ module QuietQuality
 
       private
 
-      def changed_lines_for(diff)
-        GitDiffParser.parse(diff).flat_map do |parsed_diff|
-          parsed_diff.changed_line_numbers.to_set
-        end
-      end
-
       def committed_changed_files(base, sha)
         ChangedFiles.new(committed_changes(base, sha))
       end

--- a/spec/quiet_quality/executors/base_executor_spec.rb
+++ b/spec/quiet_quality/executors/base_executor_spec.rb
@@ -1,0 +1,11 @@
+require_relative "./executor_examples"
+
+RSpec.describe QuietQuality::Executors::BaseExecutor do
+  let(:rspec_options) { tool_options(:rspec, limit_targets: true, filter_messages: false) }
+  let(:rubocop_options) { tool_options(:rubocop, limit_targets: false, filter_messages: true) }
+  let(:tools) { [rspec_options, rubocop_options] }
+  let(:changed_files) { instance_double(QuietQuality::ChangedFiles) }
+  subject(:executor) { described_class.new(tools: tools, changed_files: changed_files) }
+
+  include_examples "executes the pipelines"
+end

--- a/spec/quiet_quality/messages_spec.rb
+++ b/spec/quiet_quality/messages_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe QuietQuality::Messages do
   let(:m1_data) { {path: "/foo/1", body: "body1", start_line: 1, level: "high"} }
   let(:m2_data) { {path: "/foo/2", body: "body2", start_line: 2, stop_line: 5} }
-  let(:m1) { QuietQuality::Message.new(**m1_data) }
-  let(:m2) { QuietQuality::Message.new(**m2_data) }
+  let(:m1) { QuietQuality::Message.load(m1_data) }
+  let(:m2) { QuietQuality::Message.load(m2_data) }
   let(:supplied_messages) { [m1, m2] }
   subject(:messages) { described_class.new(supplied_messages) }
 

--- a/spec/quiet_quality/version_control_systems/git_spec.rb
+++ b/spec/quiet_quality/version_control_systems/git_spec.rb
@@ -110,6 +110,17 @@ RSpec.describe QuietQuality::VersionControlSystems::Git do
           it "should not include the untracked line numbers" do
             expect(changed_files.file("j.txt").entire?).to eq true
           end
+
+          context "when capture3 fails" do
+            before { stub_capture3(status: 28) }
+
+            it "raises an appropriate exception" do
+              expect { changed_files }.to raise_error(
+                QuietQuality::VersionControlSystems::Git::Error,
+                "git ls-files failed"
+              )
+            end
+          end
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,29 @@ require "pry"
 
 if ENV["SIMPLECOV"]
   require "simplecov"
+
+  class ProblemsFormatter
+    def format(result)
+      warn result.groups.map { |name, files| format_group(name, files) }
+    end
+
+    private
+
+    def format_group(name, files)
+      problem_files = files.select { |f| f.covered_percent < 100.0 }
+      if problem_files.any?
+        header = "#{name}: coverage missing\n"
+        rows = problem_files.map { |f| "    #{f.filename} (#{f.covered_percent.round(2)}%)\n" }
+        ([header] + rows).join
+      else
+        "#{name}: fully covered\n"
+      end
+    end
+  end
+
   SimpleCov.start do
+    formatter(ProblemsFormatter) if ENV["SIMPLECOV_TEXT"]
+    add_group "Tools", "lib/quiet_quality/tools/"
     minimum_coverage line: 100
     add_filter "spec/"
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,11 @@ require "rspec"
 require "rspec/its"
 require "pry"
 
+if ENV["SIMPLECOV"]
+  require "simplecov"
+  SimpleCov.start
+end
+
 require File.expand_path("../../lib/quiet_quality", __FILE__)
 
 gem_root = File.expand_path("../..", __FILE__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,9 @@ require "pry"
 
 if ENV["SIMPLECOV"]
   require "simplecov"
-  SimpleCov.start
+  SimpleCov.start do
+    minimum_coverage line: 100
+  end
 end
 
 require File.expand_path("../../lib/quiet_quality", __FILE__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ if ENV["SIMPLECOV"]
   require "simplecov"
   SimpleCov.start do
     minimum_coverage line: 100
+    add_filter "spec/"
   end
 end
 

--- a/spec/support/message_setup.rb
+++ b/spec/support/message_setup.rb
@@ -15,7 +15,7 @@ module MessageSetup
   end
 
   def generate_message(**attrs)
-    QuietQuality::Message.new(**generate_message_attributes(attrs))
+    QuietQuality::Message.load(generate_message_attributes(attrs))
   end
 
   def generate_messages(count, **attrs)

--- a/spec/support/option_setup.rb
+++ b/spec/support/option_setup.rb
@@ -15,21 +15,22 @@ module OptionSetup
 
   def build_options(**attrs)
     opts = QuietQuality::Config::Options.new
-    [:comparison_branch, :annotator, :executor, :logging].each do |attr|
-      opts.send("#{attr}=", send("#{attr}_from", attrs[attr])) if attrs[attr]
-    end
+    maybe_set_option(opts, attrs, :comparison_branch)
+    maybe_set_option(opts, attrs, :logging)
+    maybe_set_option(opts, attrs, :annotator, :annotator_from)
+    maybe_set_option(opts, attrs, :executor, :executor_from)
     opts.tools = tool_options_from(attrs)
     opts
   end
 
   private
 
-  def comparison_branch_from(name)
-    name
-  end
+  def maybe_set_option(opts, attrs, key, transform = nil)
+    value = attrs[key]
+    return unless value
 
-  def logging_from(level)
-    level
+    value = send(transform, value) if transform
+    opts.send("#{key}=", value)
   end
 
   def set_global_options(po, global_options)


### PR DESCRIPTION
While we had simplecov _installed_, we weren't actually running it during the test executions.

* Turn simplecov on (when `ENV["SIMPLECOV"]` is supplied)
* set a minimum line-coverage of 100%
  - fix all the resulting coverage issues
  - exclude the `spec/` directory - there are some portions of the spec/support directory that _aren't_ executed, but are present for completeness; writing tests for them would be silly.
* Add a custom formatter, to use in CI (well, when `ENV["SIMPLECOV_TEXT"]` is supplied, which prints out all of the _problems_, but not all of the files. One might expect SimpleFormatter to do this, but not only is it way too verbose, it's also completely broken in enough ways that it's not even clear why it exists.

### Examples

Output with no coverage issues:
```
........................................................................................................................................................................................................................................................................................

Finished in 0.94038 seconds (files took 0.2632 seconds to load)
708 examples, 0 failures

Randomized with seed 2089

Tools: fully covered
Ungrouped: fully covered
```

Output with _some_ coverage issues:
```
.......................................

Finished in 0.91588 seconds (files took 0.24947 seconds to load)
681 examples, 0 failures

Randomized with seed 39969

Tools: coverage missing
    /Users/emueller/src/quiet_quality/lib/quiet_quality/tools/markdown_lint/runner.rb (53.33%)
Ungrouped: fully covered
Line coverage (99.32%) is below the expected minimum coverage (100.00%).
SimpleCov failed with exit 2 due to a coverage related error
```