### PR TITLE
Indicate which tool produced a message

### DIFF
--- a/lib/quiet_quality/annotators/github_stdout.rb
+++ b/lib/quiet_quality/annotators/github_stdout.rb
@@ -18,10 +18,12 @@ module QuietQuality
       # ::warning file={name},line={line},title={title}::{message}
       # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message
       def self.format(message)
+        title = message.tool_name.to_s
+        title += " #{message.rule}" if message.rule
         attributes = {
           file: message.path,
           line: message.annotated_line || message.start_line,
-          title: message.rule
+          title: title
         }.compact
 
         attributes_string = attributes.map { |k, v| "#{k}=#{v}" }.join(",")

--- a/lib/quiet_quality/cli/presenter.rb
+++ b/lib/quiet_quality/cli/presenter.rb
@@ -70,7 +70,7 @@ module QuietQuality
         line_range = line_range_for(msg)
         rule_string = msg.rule ? "  [#{msg.rule}]" : ""
         truncated_body = reduce_text(msg.body, 120)
-        logger.puts "  #{msg.path}:#{line_range}#{rule_string}  #{truncated_body}"
+        logger.puts "#{msg.tool_name}  #{msg.path}:#{line_range}#{rule_string}  #{truncated_body}"
       end
     end
   end

--- a/lib/quiet_quality/message.rb
+++ b/lib/quiet_quality/message.rb
@@ -1,5 +1,7 @@
 module QuietQuality
   class Message
+    REQUIRED_ATTRS = %w[path body start_line tool_name].freeze
+
     attr_writer :annotated_line
 
     def self.load(hash)
@@ -8,6 +10,7 @@ module QuietQuality
 
     def initialize(**attrs)
       @attrs = attrs.map { |k, v| [k.to_s, v] }.to_h
+      validate_attrs!
     end
 
     def to_h
@@ -44,6 +47,14 @@ module QuietQuality
 
     def tool_name
       @_tool_name ||= @attrs.fetch("tool_name")
+    end
+
+    private
+
+    def validate_attrs!
+      REQUIRED_ATTRS.each do |attr|
+        raise ArgumentError, "Missing required attribute #{attr}" unless @attrs[attr]
+      end
     end
   end
 end

--- a/lib/quiet_quality/message.rb
+++ b/lib/quiet_quality/message.rb
@@ -1,7 +1,6 @@
 module QuietQuality
   class Message
-    attr_accessor :annotated_line
-    attr_reader :path, :body, :start_line, :stop_line, :level, :rule
+    attr_writer :annotated_line
 
     def self.load(hash)
       new(**hash)
@@ -9,17 +8,42 @@ module QuietQuality
 
     def initialize(**attrs)
       @attrs = attrs.map { |k, v| [k.to_s, v] }.to_h
-      @path = @attrs.fetch("path")
-      @body = @attrs.fetch("body")
-      @start_line = @attrs.fetch("start_line")
-      @stop_line = @attrs.fetch("stop_line", @start_line)
-      @annotated_line = @attrs.fetch("annotated_line", nil)
-      @level = @attrs.fetch("level", nil)
-      @rule = @attrs.fetch("rule", nil)
     end
 
     def to_h
       @attrs.map { |k, v| [k.to_s, v] }.to_h
+    end
+
+    def path
+      @_path ||= @attrs.fetch("path")
+    end
+
+    def body
+      @_body ||= @attrs.fetch("body")
+    end
+
+    def start_line
+      @_start_line ||= @attrs.fetch("start_line")
+    end
+
+    def stop_line
+      @_stop_line ||= @attrs.fetch("stop_line", start_line)
+    end
+
+    def annotated_line
+      @annotated_line ||= @attrs.fetch("annotated_line", nil)
+    end
+
+    def level
+      @_level ||= @attrs.fetch("level", nil)
+    end
+
+    def rule
+      @_rule ||= @attrs.fetch("rule", nil)
+    end
+
+    def tool_name
+      @_tool_name ||= @attrs.fetch("tool_name")
     end
   end
 end

--- a/lib/quiet_quality/message.rb
+++ b/lib/quiet_quality/message.rb
@@ -25,6 +25,10 @@ module QuietQuality
       @_body ||= @attrs.fetch("body")
     end
 
+    def tool_name
+      @_tool_name ||= @attrs.fetch("tool_name")
+    end
+
     def start_line
       @_start_line ||= @attrs.fetch("start_line")
     end
@@ -43,10 +47,6 @@ module QuietQuality
 
     def rule
       @_rule ||= @attrs.fetch("rule", nil)
-    end
-
-    def tool_name
-      @_tool_name ||= @attrs.fetch("tool_name")
     end
 
     private

--- a/lib/quiet_quality/tools/brakeman.rb
+++ b/lib/quiet_quality/tools/brakeman.rb
@@ -3,6 +3,7 @@ require_relative "./rubocop"
 module QuietQuality
   module Tools
     module Brakeman
+      TOOL_NAME = :brakeman
     end
   end
 end

--- a/lib/quiet_quality/tools/brakeman/parser.rb
+++ b/lib/quiet_quality/tools/brakeman/parser.rb
@@ -37,7 +37,14 @@ module QuietQuality
           line = warning.fetch(:line)
           level = warning.fetch(:confidence, nil)
           rule = warning.fetch(:warning_type)
-          Message.new(path: path, body: body, start_line: line, level: level, rule: rule)
+          Message.new(
+            path: path,
+            body: body,
+            start_line: line,
+            level: level,
+            rule: rule,
+            tool_name: TOOL_NAME
+          )
         end
       end
     end

--- a/lib/quiet_quality/tools/brakeman/runner.rb
+++ b/lib/quiet_quality/tools/brakeman/runner.rb
@@ -3,7 +3,7 @@ module QuietQuality
     module Brakeman
       class Runner < BaseRunner
         def tool_name
-          :brakeman
+          TOOL_NAME
         end
 
         def command

--- a/lib/quiet_quality/tools/haml_lint.rb
+++ b/lib/quiet_quality/tools/haml_lint.rb
@@ -1,6 +1,7 @@
 module QuietQuality
   module Tools
     module HamlLint
+      TOOL_NAME = :haml_lint
     end
   end
 end

--- a/lib/quiet_quality/tools/haml_lint/parser.rb
+++ b/lib/quiet_quality/tools/haml_lint/parser.rb
@@ -36,7 +36,8 @@ module QuietQuality
             body: offense.fetch(:message),
             start_line: offense.dig(:location, :line),
             level: offense.fetch(:severity, nil),
-            rule: offense.fetch(:linter_name, nil)
+            rule: offense.fetch(:linter_name, nil),
+            tool_name: TOOL_NAME
           )
         end
       end

--- a/lib/quiet_quality/tools/haml_lint/runner.rb
+++ b/lib/quiet_quality/tools/haml_lint/runner.rb
@@ -3,7 +3,7 @@ module QuietQuality
     module HamlLint
       class Runner < RelevantRunner
         def tool_name
-          :haml_lint
+          TOOL_NAME
         end
 
         def no_files_output

--- a/lib/quiet_quality/tools/markdown_lint.rb
+++ b/lib/quiet_quality/tools/markdown_lint.rb
@@ -1,6 +1,7 @@
 module QuietQuality
   module Tools
     module MarkdownLint
+      TOOL_NAME = :markdown_lint
     end
   end
 end

--- a/lib/quiet_quality/tools/markdown_lint/parser.rb
+++ b/lib/quiet_quality/tools/markdown_lint/parser.rb
@@ -25,7 +25,8 @@ module QuietQuality
             path: entry.fetch(:filename),
             start_line: entry.fetch(:line),
             rule: entry.fetch(:description),
-            body: entry.fetch(:docs)
+            body: entry.fetch(:docs),
+            tool_name: TOOL_NAME
           )
         end
       end

--- a/lib/quiet_quality/tools/markdown_lint/runner.rb
+++ b/lib/quiet_quality/tools/markdown_lint/runner.rb
@@ -3,7 +3,7 @@ module QuietQuality
     module MarkdownLint
       class Runner < RelevantRunner
         def tool_name
-          :markdown_lint
+          TOOL_NAME
         end
 
         def no_files_output

--- a/lib/quiet_quality/tools/rspec.rb
+++ b/lib/quiet_quality/tools/rspec.rb
@@ -1,6 +1,7 @@
 module QuietQuality
   module Tools
     module Rspec
+      TOOL_NAME = :rspec
     end
   end
 end

--- a/lib/quiet_quality/tools/rspec/parser.rb
+++ b/lib/quiet_quality/tools/rspec/parser.rb
@@ -37,7 +37,13 @@ module QuietQuality
           body = example.dig(:exception, :message) || example.fetch(:description)
           line = example.fetch(:line_number)
           rule = example.dig(:exception, :class) || "Failed Example"
-          Message.new(path: path, body: body, start_line: line, rule: rule)
+          Message.new(
+            path: path,
+            body: body,
+            start_line: line,
+            rule: rule,
+            tool_name: TOOL_NAME
+          )
         end
       end
     end

--- a/lib/quiet_quality/tools/rspec/runner.rb
+++ b/lib/quiet_quality/tools/rspec/runner.rb
@@ -3,7 +3,7 @@ module QuietQuality
     module Rspec
       class Runner < RelevantRunner
         def tool_name
-          :rspec
+          TOOL_NAME
         end
 
         def no_files_output

--- a/lib/quiet_quality/tools/rubocop.rb
+++ b/lib/quiet_quality/tools/rubocop.rb
@@ -1,6 +1,7 @@
 module QuietQuality
   module Tools
     module Rubocop
+      TOOL_NAME = :rubocop
     end
   end
 end

--- a/lib/quiet_quality/tools/rubocop/parser.rb
+++ b/lib/quiet_quality/tools/rubocop/parser.rb
@@ -37,8 +37,13 @@ module QuietQuality
             start_line: offense.dig(:location, :start_line),
             stop_line: offense.dig(:location, :last_line),
             level: offense.fetch(:severity, nil),
-            rule: offense.fetch(:cop_name, nil)
+            rule: offense.fetch(:cop_name, nil),
+            tool_name: tool_name
           )
+        end
+
+        def tool_name
+          TOOL_NAME
         end
       end
     end

--- a/lib/quiet_quality/tools/rubocop/runner.rb
+++ b/lib/quiet_quality/tools/rubocop/runner.rb
@@ -3,7 +3,7 @@ module QuietQuality
     module Rubocop
       class Runner < RelevantRunner
         def tool_name
-          :rubocop
+          TOOL_NAME
         end
 
         def no_files_output

--- a/lib/quiet_quality/tools/standardrb.rb
+++ b/lib/quiet_quality/tools/standardrb.rb
@@ -3,6 +3,7 @@ require_relative "./rubocop"
 module QuietQuality
   module Tools
     module Standardrb
+      TOOL_NAME = :standardrb
     end
   end
 end

--- a/lib/quiet_quality/tools/standardrb/parser.rb
+++ b/lib/quiet_quality/tools/standardrb/parser.rb
@@ -2,6 +2,9 @@ module QuietQuality
   module Tools
     module Standardrb
       class Parser < Rubocop::Parser
+        def tool_name
+          TOOL_NAME
+        end
       end
     end
   end

--- a/lib/quiet_quality/tools/standardrb/runner.rb
+++ b/lib/quiet_quality/tools/standardrb/runner.rb
@@ -3,7 +3,7 @@ module QuietQuality
     module Standardrb
       class Runner < RelevantRunner
         def tool_name
-          :standardrb
+          TOOL_NAME
         end
 
         def no_files_output

--- a/spec/quiet_quality/annotation_locator_spec.rb
+++ b/spec/quiet_quality/annotation_locator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe QuietQuality::AnnotationLocator do
   subject(:locator) { described_class.new(changed_files: changed_files) }
 
   def build_message(path, body, start, stop = nil)
-    QuietQuality::Message.new(path: path, body: body, start_line: start, stop_line: stop)
+    generate_message(path: path, body: body, start_line: start, stop_line: stop)
   end
 
   describe "#update!" do

--- a/spec/quiet_quality/annotators/github_stdout_spec.rb
+++ b/spec/quiet_quality/annotators/github_stdout_spec.rb
@@ -9,47 +9,49 @@ RSpec.describe QuietQuality::Annotators::GithubStdout do
         body: "My Message",
         start_line: start_line,
         annotated_line: annotated_line,
-        rule: rule
+        rule: rule,
+        tool_name: tool_name
       )
     end
     let(:start_line) { 20 }
     let(:annotated_line) { 25 }
     let(:rule) { "MyRule" }
+    let(:tool_name) { :flaky_spec_creator }
     subject(:formatted_line) { described_class.format(message) }
 
     context "with annotated_line set" do
       let(:annotated_line) { 25 }
-      it { is_expected.to eq("::warning file=foo/bar.rb,line=25,title=MyRule::My Message") }
+      it { is_expected.to eq("::warning file=foo/bar.rb,line=25,title=flaky_spec_creator MyRule::My Message") }
     end
 
     context "without annotated_line set" do
       let(:annotated_line) { nil }
-      it { is_expected.to eq("::warning file=foo/bar.rb,line=20,title=MyRule::My Message") }
+      it { is_expected.to eq("::warning file=foo/bar.rb,line=20,title=flaky_spec_creator MyRule::My Message") }
     end
 
     context "with a rule" do
       let(:rule) { "MyRule" }
-      it { is_expected.to eq("::warning file=foo/bar.rb,line=25,title=MyRule::My Message") }
+      it { is_expected.to eq("::warning file=foo/bar.rb,line=25,title=flaky_spec_creator MyRule::My Message") }
     end
 
     context "with no rule" do
       let(:rule) { nil }
-      it { is_expected.to eq("::warning file=foo/bar.rb,line=25::My Message") }
+      it { is_expected.to eq("::warning file=foo/bar.rb,line=25,title=flaky_spec_creator::My Message") }
     end
   end
 
   describe "#annotate!" do
-    let(:m1) { QuietQuality::Message.new(path: "foo.rb", body: "Msg1", start_line: 1) }
-    let(:m2) { QuietQuality::Message.new(path: "bar.rb", body: "Msg2", start_line: 2, rule: "Title") }
-    let(:m3) { QuietQuality::Message.new(path: "baz.rb", body: "Msg3", start_line: 3, annotated_line: 5) }
+    let(:m1) { QuietQuality::Message.new(path: "foo.rb", body: "Msg1", start_line: 1, tool_name: :you_didnt_write_enough_comments) }
+    let(:m2) { QuietQuality::Message.new(path: "bar.rb", body: "Msg2", start_line: 2, rule: "Title", tool_name: :you_wrote_too_many_comments) }
+    let(:m3) { QuietQuality::Message.new(path: "baz.rb", body: "Msg3", start_line: 3, annotated_line: 5, tool_name: :you_wrote_too_many_specs) }
     let(:messages) { [m1, m2, m3] }
     subject(:annotate!) { annotator.annotate!(messages) }
 
     it "writes the expected messages to the output stream" do
       annotate!
-      expect(fake_stdout).to have_received(:puts).with("::warning file=foo.rb,line=1::Msg1")
-      expect(fake_stdout).to have_received(:puts).with("::warning file=bar.rb,line=2,title=Title::Msg2")
-      expect(fake_stdout).to have_received(:puts).with("::warning file=baz.rb,line=5::Msg3")
+      expect(fake_stdout).to have_received(:puts).with("::warning file=foo.rb,line=1,title=you_didnt_write_enough_comments::Msg1")
+      expect(fake_stdout).to have_received(:puts).with("::warning file=bar.rb,line=2,title=you_wrote_too_many_comments Title::Msg2")
+      expect(fake_stdout).to have_received(:puts).with("::warning file=baz.rb,line=5,title=you_wrote_too_many_specs::Msg3")
     end
 
     context "when given more messages than it can annotate" do
@@ -57,9 +59,9 @@ RSpec.describe QuietQuality::Annotators::GithubStdout do
 
       it "writes the expected messages to the output stream" do
         annotate!
-        expect(fake_stdout).to have_received(:puts).with("::warning file=foo.rb,line=1::Msg1")
-        expect(fake_stdout).to have_received(:puts).with("::warning file=bar.rb,line=2,title=Title::Msg2")
-        expect(fake_stdout).not_to have_received(:puts).with("::warning file=baz.rb,line=5::Msg3")
+        expect(fake_stdout).to have_received(:puts).with("::warning file=foo.rb,line=1,title=you_didnt_write_enough_comments::Msg1")
+        expect(fake_stdout).to have_received(:puts).with("::warning file=bar.rb,line=2,title=you_wrote_too_many_comments Title::Msg2")
+        expect(fake_stdout).not_to have_received(:puts).with("::warning file=baz.rb,line=5,title=you_wrote_too_many_specs::Msg3")
       end
     end
   end

--- a/spec/quiet_quality/cli/entrypoint_spec.rb
+++ b/spec/quiet_quality/cli/entrypoint_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
 
     context "when some of the tools fail" do
       let(:outcomes) { [build_failure(:rspec), build_success(:rubocop)] }
-      let(:m1) { QuietQuality::Message.new(path: "foo.rb", body: "Msg1", start_line: 1) }
-      let(:m2) { QuietQuality::Message.new(path: "bar.rb", body: "Msg2", start_line: 2, rule: "Title") }
-      let(:m3) { QuietQuality::Message.new(path: "baz.rb", body: "Msg3", start_line: 3, stop_line: 7, annotated_line: 5) }
+      let(:m1) { QuietQuality::Message.new(path: "foo.rb", body: "Msg1", start_line: 1, tool_name: :just_delete_everything) }
+      let(:m2) { QuietQuality::Message.new(path: "bar.rb", body: "Msg2", start_line: 2, rule: "Title", tool_name: :complexity_checks_that_make_things_worse) }
+      let(:m3) { QuietQuality::Message.new(path: "baz.rb", body: "Msg3", start_line: 3, stop_line: 7, annotated_line: 5, tool_name: :not_enough_extra_newlines) }
       let(:messages) { QuietQuality::Messages.new([m1, m2, m3]) }
 
       it { is_expected.to be_a(described_class) }
@@ -101,9 +101,9 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
 
         it "writes the proper annotations to stdout" do
           execute
-          expect(output_stream).to have_received(:puts).with("::warning file=foo.rb,line=1::Msg1")
-          expect(output_stream).to have_received(:puts).with("::warning file=bar.rb,line=2,title=Title::Msg2")
-          expect(output_stream).to have_received(:puts).with("::warning file=baz.rb,line=5::Msg3")
+          expect(output_stream).to have_received(:puts).with("::warning file=foo.rb,line=1,title=just_delete_everything::Msg1")
+          expect(output_stream).to have_received(:puts).with("::warning file=bar.rb,line=2,title=complexity_checks_that_make_things_worse Title::Msg2")
+          expect(output_stream).to have_received(:puts).with("::warning file=baz.rb,line=5,title=not_enough_extra_newlines::Msg3")
         end
       end
 

--- a/spec/quiet_quality/cli/presenter_spec.rb
+++ b/spec/quiet_quality/cli/presenter_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe QuietQuality::Cli::Presenter do
   let(:haml_lint_outcome) { build_failure(:haml_lint, "haml_lint output", "haml_lint logging") }
   let(:outcomes) { [rspec_outcome, haml_lint_outcome] }
 
-  let(:message_1) { generate_message(path: "foo.rb", body: "foo \n  body", start_line: 55, stop_line: 55, rule: "foorule") }
-  let(:message_2) { generate_message(path: "bar.rb", body: "barbody" + "x" * 200, start_line: 8, stop_line: 14, rule: "barule") }
+  let(:message_1) { generate_message(path: "foo.rb", body: "foo \n  body", start_line: 55, stop_line: 55, rule: "foorule", tool_name: :ai_fixes_ur_code) }
+  let(:message_2) { generate_message(path: "bar.rb", body: "barbody" + "x" * 200, start_line: 8, stop_line: 14, rule: "barule", tool_name: :sudo_make_me_a_sandwhich) }
   let(:messages) { QuietQuality::Messages.new([message_1, message_2]) }
 
   subject(:presenter) { described_class.new(logger: logger, logging: logging, outcomes: outcomes, messages: messages) }
@@ -43,8 +43,8 @@ RSpec.describe QuietQuality::Cli::Presenter do
         expect(logger).to have_received(:puts).with("--- Passed: rspec").ordered
         expect(logger).to have_received(:puts).with("--- Failed: haml_lint").ordered
         expect(logger).to have_received(:puts).with("\n\n2 messages:").ordered
-        expect(logger).to have_received(:puts).with("  foo.rb:55  [foorule]  foo\\nbody").ordered
-        expect(logger).to have_received(:puts).with("  bar.rb:8-14  [barule]  barbody" + "x" * 113).ordered
+        expect(logger).to have_received(:puts).with("ai_fixes_ur_code  foo.rb:55  [foorule]  foo\\nbody").ordered
+        expect(logger).to have_received(:puts).with("sudo_make_me_a_sandwhich  bar.rb:8-14  [barule]  barbody" + "x" * 113).ordered
       end
     end
   end

--- a/spec/quiet_quality/message_spec.rb
+++ b/spec/quiet_quality/message_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe QuietQuality::Message do
 
   it { is_expected.to be_a(QuietQuality::Message) }
 
-  shared_examples "raises a KeyError" do
-    it "raises a KeyError" do
-      expect { subject }.to raise_error(KeyError)
+  shared_examples "raises an ArgumentError" do
+    it "raises an ArgumentError" do
+      expect { subject }.to raise_error(ArgumentError)
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe QuietQuality::Message do
 
       context "when #{binding_name} isn't supplied" do
         let(binding_name) { nil }
-        include_examples "raises a KeyError"
+        include_examples "raises an ArgumentError"
       end
     end
   end

--- a/spec/quiet_quality/message_spec.rb
+++ b/spec/quiet_quality/message_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe QuietQuality::Message do
       stop_line: stop_line,
       annotated_line: annotated_line,
       level: level,
-      rule: rule
+      rule: rule,
+      tool_name: tool_name
     }.compact
   end
 
@@ -20,6 +21,7 @@ RSpec.describe QuietQuality::Message do
   let(:annotated_line) { 12 }
   let(:level) { "serious" }
   let(:rule) { "You Shall Not Pass" }
+  let(:tool_name) { :one_ring_to_rule_them_all }
 
   it { is_expected.to be_a(QuietQuality::Message) }
 
@@ -64,6 +66,7 @@ RSpec.describe QuietQuality::Message do
   include_examples "required field", :path, :path
   include_examples "required field", :body, :body
   include_examples "required field", :start_line, :start_line
+  include_examples "required field", :tool_name, :tool_name
   include_examples "field with default", :stop_line, default_binding: :start_line
   include_examples "field with default", :level, default_value: nil
   include_examples "field with default", :rule, default_value: nil
@@ -81,7 +84,8 @@ RSpec.describe QuietQuality::Message do
           "stop_line",
           "annotated_line",
           "level",
-          "rule"
+          "rule",
+          "tool_name"
         )
       end
     end
@@ -96,7 +100,8 @@ RSpec.describe QuietQuality::Message do
           "body",
           "start_line",
           "annotated_line",
-          "rule"
+          "rule",
+          "tool_name"
         )
       end
     end

--- a/spec/quiet_quality/messages_spec.rb
+++ b/spec/quiet_quality/messages_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe QuietQuality::Messages do
-  let(:m1_data) { {path: "/foo/1", body: "body1", start_line: 1, level: "high"} }
-  let(:m2_data) { {path: "/foo/2", body: "body2", start_line: 2, stop_line: 5} }
+  let(:m1_data) { {path: "/foo/1", body: "body1", start_line: 1, level: "high", tool_name: "baz"} }
+  let(:m2_data) { {path: "/foo/2", body: "body2", start_line: 2, stop_line: 5, tool_name: "qux"} }
   let(:m1) { QuietQuality::Message.load(m1_data) }
   let(:m2) { QuietQuality::Message.load(m2_data) }
   let(:supplied_messages) { [m1, m2] }
@@ -21,8 +21,8 @@ RSpec.describe QuietQuality::Messages do
     let(:json) do
       <<~JSON
         [
-          {"path": "/foo/1", "body": "body1", "start_line": 1, "level": "high"},
-          {"path": "/foo/2", "body": "body2", "start_line": 2, "stop_line": 5}
+          {"path": "/foo/1", "body": "body1", "start_line": 1, "level": "high", "tool_name": "baz"},
+          {"path": "/foo/2", "body": "body2", "start_line": 2, "stop_line": 5, "tool_name": "qux"}
         ]
       JSON
     end
@@ -44,10 +44,12 @@ RSpec.describe QuietQuality::Messages do
           body: body1
           start_line: 1
           level: high
+          tool_name: baz
         - path: "/foo/2"
           body: body2
           start_line: 2
           stop_line: 5
+          tool_name: qux
       YAML
     end
     subject(:loaded_yaml) { described_class.load_yaml(yaml) }
@@ -70,8 +72,8 @@ RSpec.describe QuietQuality::Messages do
 
     it "includes the expected data in each" do
       expect(to_hashes).to eq([
-        {"path" => "/foo/1", "body" => "body1", "start_line" => 1, "level" => "high"},
-        {"path" => "/foo/2", "body" => "body2", "start_line" => 2, "stop_line" => 5}
+        {"path" => "/foo/1", "body" => "body1", "start_line" => 1, "level" => "high", "tool_name" => "baz"},
+        {"path" => "/foo/2", "body" => "body2", "start_line" => 2, "stop_line" => 5, "tool_name" => "qux"}
       ])
     end
   end

--- a/spec/quiet_quality/tools/brakeman/parser_spec.rb
+++ b/spec/quiet_quality/tools/brakeman/parser_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe QuietQuality::Tools::Brakeman::Parser do
         expect(m.start_line).to eq(3)
         expect(m.level).to eq("High")
         expect(m.rule).to eq("SQL Injection")
+        expect(m.tool_name).to eq(:brakeman)
       end
     end
 

--- a/spec/quiet_quality/tools/haml_lint/parser_spec.rb
+++ b/spec/quiet_quality/tools/haml_lint/parser_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe QuietQuality::Tools::HamlLint::Parser do
         expect(messages.first.start_line).to eq(1)
         expect(messages.first.level).to eq("warning")
         expect(messages.first.rule).to eq("ImplicitDiv")
+        expect(messages.first.tool_name).to eq(:haml_lint)
       end
     end
   end

--- a/spec/quiet_quality/tools/markdown_lint/parser_spec.rb
+++ b/spec/quiet_quality/tools/markdown_lint/parser_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe QuietQuality::Tools::MarkdownLint::Parser do
         expect(m.stop_line).to eq(23)
         expect(m.rule).to eq("Line length")
         expect(m.body).to eq("https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md013---line-length")
+        expect(m.tool_name).to eq(:markdown_lint)
       end
     end
   end

--- a/spec/quiet_quality/tools/rspec/parser_spec.rb
+++ b/spec/quiet_quality/tools/rspec/parser_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe QuietQuality::Tools::Rspec::Parser do
         expect(m.start_line).to eq(73)
         expect(m.rule).to eq("Failed Example")
         expect(m.body).to eq("is expected to eq \"wrong fake output\"")
+        expect(m.tool_name).to eq(:rspec)
       end
     end
   end

--- a/spec/quiet_quality/tools/rubocop/parser_spec.rb
+++ b/spec/quiet_quality/tools/rubocop/parser_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe QuietQuality::Tools::Rubocop::Parser do
         expect(messages.first.stop_line).to eq(10)
         expect(messages.first.level).to eq("convention")
         expect(messages.first.rule).to eq("Style/EmptyMethod")
+        expect(messages.first.tool_name).to eq(:rubocop)
       end
     end
   end

--- a/spec/quiet_quality/tools/standardrb/parser_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/parser_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe QuietQuality::Tools::Standardrb::Parser do
         expect(messages.first.stop_line).to eq(10)
         expect(messages.first.level).to eq("convention")
         expect(messages.first.rule).to eq("Style/EmptyMethod")
+        expect(messages.first.tool_name).to eq(:standardrb)
       end
     end
   end

--- a/spec/support/message_setup.rb
+++ b/spec/support/message_setup.rb
@@ -10,7 +10,8 @@ module MessageSetup
       stop_line: attrs.fetch(:stop_line, start_line + Random.rand(4)),
       annotated_line: attrs.fetch(:annotated_line, nil),
       level: attrs.fetch(:level, "Moderate"),
-      rule: attrs.fetch(:rule, "FakeRule")
+      rule: attrs.fetch(:rule, "FakeRule"),
+      tool_name: attrs.fetch(:tool_name, "fake_tool")
     }
   end
 


### PR DESCRIPTION
Log the tool_name in front of messages and as a part of the GitHub annotation.

<img width="662" alt="Screenshot 2023-06-02 at 8 53 09 PM" src="https://github.com/nevinera/quiet_quality/assets/22665228/af50b51c-5374-4f33-98fc-525350c39a0c">
s

Resolves #72 