### PR TITLE
Update the Rspec::Parser to ignore simplecov output mixed into the rspec json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   simplecov may write into the rspec json output. (#91, resolves #86)
 * Include the name of the originating tool in the printed message, and the
   annotation, when a warning is presented. (#90 resolves #72)
+* Support `normal` as a logging level, and the `--normal` and `-n` cli
+  arguments. This is the default value, so this really only matters if your
+  config file sets another value and you want to override it from the cli.
+  (#91, resolves #86)
 
 ## Release 1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Release 1.2.2
+
+* Add some code to the Rspec::Parser that _cleans_ the json of certain text that
+  simplecov may write into the rspec json output. (#91, resolves #86)
+* Include the name of the originating tool in the printed message, and the
+  annotation, when a warning is presented. (#90 resolves #72)
+
 ## Release 1.2.1
 
 * Fix the handling of the various ways to specify whether tools should limit

--- a/lib/quiet_quality/tools/rspec/parser.rb
+++ b/lib/quiet_quality/tools/rspec/parser.rb
@@ -16,8 +16,26 @@ module QuietQuality
 
         attr_reader :text
 
+        # Many people use simplecov with rspec, and its default formatter
+        # writes text output into the stdout stream of rspec even when rspec is
+        # asked for json output. I have an issue open here, and I'll get a pair
+        # of PRs together if they indicate any willingness to accept such a
+        # change: https://github.com/simplecov-ruby/simplecov/issues/1060
+        #
+        # The only stdout writes are visible on these lines:
+        # https://github.com/simplecov-ruby/simplecov-html/blob/main/lib/simplecov-html.rb#L31
+        # https://github.com/simplecov-ruby/simplecov-html/blob/main/lib/simplecov-html.rb#L80
+        #
+        # There are _hundreds_ of rspec plugins, and any of them could write to
+        # stdout - we probably won't worry about any but the most common.
+        def cleaned_text
+          @_cleaned_text ||= text
+            .gsub(/Coverage report generated.*covered.$/, "")
+            .gsub(/Encoding problems with file.*$/, "")
+        end
+
         def content
-          @_content ||= JSON.parse(text, symbolize_names: true)
+          @_content ||= JSON.parse(cleaned_text, symbolize_names: true)
         end
 
         def examples

--- a/lib/quiet_quality/version.rb
+++ b/lib/quiet_quality/version.rb
@@ -1,3 +1,3 @@
 module QuietQuality
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/spec/fixtures/tools/rspec/no-failures.with-simplecov-encoding-errors.json
+++ b/spec/fixtures/tools/rspec/no-failures.with-simplecov-encoding-errors.json
@@ -1,0 +1,45 @@
+{
+  "version": "3.12.2",
+  "seed": 64304,
+  "examples": [
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:3:2]",
+      "description": "calls standardrb correctly, with no targets",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full and contains too many ruby files calls standardrb correctly, with no targets",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 75,
+      "run_time": 0.000185,
+      "pending_message": null
+    },
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:1:1]",
+      "description": "does not call standardrb",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full but contains no ruby files does not call standardrb",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 54,
+      "run_time": 0.000125,
+      "pending_message": null
+    },
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:2:2]",
+      "description": "calls standardrb correctly, with changed and relevant targets",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full and contains some ruby files calls standardrb correctly, with changed and relevant targets",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 63,
+      "run_time": 0.000148,
+      "pending_message": null
+    }
+  ],
+  "summary": {
+    "duration": 0.018751,
+    "example_count": 3,
+    "failure_count": 0,
+    "pending_count": 0,
+    "errors_outside_of_examples_count": 0
+  },
+  "summary_line": "89 examples, 0 failures"
+}Encoding problems with file foo.rb. Simplecov/ERB can't handle non ASCII characters in filenames. Error: Fake error.
+Encoding problems with file bar.rb. Simplecov/ERB can't handle non ASCII characters in filenames. Error: Fake error.

--- a/spec/fixtures/tools/rspec/no-failures.with-simplecov.json
+++ b/spec/fixtures/tools/rspec/no-failures.with-simplecov.json
@@ -1,0 +1,44 @@
+{
+  "version": "3.12.2",
+  "seed": 64304,
+  "examples": [
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:3:2]",
+      "description": "calls standardrb correctly, with no targets",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full and contains too many ruby files calls standardrb correctly, with no targets",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 75,
+      "run_time": 0.000185,
+      "pending_message": null
+    },
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:1:1]",
+      "description": "does not call standardrb",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full but contains no ruby files does not call standardrb",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 54,
+      "run_time": 0.000125,
+      "pending_message": null
+    },
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:2:2]",
+      "description": "calls standardrb correctly, with changed and relevant targets",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full and contains some ruby files calls standardrb correctly, with changed and relevant targets",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 63,
+      "run_time": 0.000148,
+      "pending_message": null
+    }
+  ],
+  "summary": {
+    "duration": 0.018751,
+    "example_count": 3,
+    "failure_count": 0,
+    "pending_count": 0,
+    "errors_outside_of_examples_count": 0
+  },
+  "summary_line": "89 examples, 0 failures"
+}Coverage report generated for RSpec to /Users/emueller/src/quiet_quality/coverage. 1072 / 1072 LOC (100.0%) covered.

--- a/spec/quiet_quality/tools/rspec/parser_spec.rb
+++ b/spec/quiet_quality/tools/rspec/parser_spec.rb
@@ -47,5 +47,17 @@ RSpec.describe QuietQuality::Tools::Rspec::Parser do
         expect(m.tool_name).to eq(:rspec)
       end
     end
+
+    context "when simplecov dumps its non-json results output into the stream" do
+      let(:text) { fixture_content("tools", "rspec", "no-failures.with-simplecov.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+      it { is_expected.to be_empty }
+    end
+
+    context "when simplecov dumps multiple filename encoding problems into the stream" do
+      let(:text) { fixture_content("tools", "rspec", "no-failures.with-simplecov-encoding-errors.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+      it { is_expected.to be_empty }
+    end
   end
 end


### PR DESCRIPTION
`simplecov-html`, the default simplecov output formatter, dumps text output into stderr even when rspec is asked for `--format json`, causing the output stream to be unparseable. While this is truly an issue with `simplecov` (and I've started a conversation [here](https://github.com/simplecov-ruby/simplecov/issues/1060)), we can work around it from our end because the text being written into the output stream is very limited and specific.

So - as part of parsing the output of rspec, look for non-json simplecov output strings and strip them from the text before json-parsing.

You can actually produce this error on _this_ repository in `main` by running `SIMPLECOV=true bin/qq`, which totally passes in this branch ;-)