### PR TITLE
Support `--logging normal` (and variants)

### DIFF
--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -137,6 +137,10 @@ module QuietQuality
       end
 
       def setup_logging_options(parser)
+        parser.on("-n", "--normal", "Print outcomes and messages") do
+          set_global_option(:logging, Config::Logging::NORMAL)
+        end
+
         parser.on("-l", "--light", "Print aggregated results only") do
           set_global_option(:logging, Config::Logging::LIGHT)
         end

--- a/lib/quiet_quality/config/logging.rb
+++ b/lib/quiet_quality/config/logging.rb
@@ -3,11 +3,12 @@ module QuietQuality
     class Logging
       LIGHT = :light
       QUIET = :quiet
-      LEVELS = [LIGHT, QUIET].freeze
+      NORMAL = :normal
+      LEVELS = [LIGHT, QUIET, NORMAL].freeze
 
       attr_accessor :level
 
-      def initialize(level: nil)
+      def initialize(level: NORMAL)
         @level = level
       end
 

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe QuietQuality::Cli::ArgParser do
             -B, --comparison-branch BRANCH   Specify the branch to compare against
             -f, --filter-messages [tool]     Filter messages from tool(s) based on changed lines
             -u, --unfiltered [tool]          Don't filter messages from tool(s)
+            -n, --normal                     Print outcomes and messages
             -l, --light                      Print aggregated results only
             -q, --quiet                      Don't print results, only return a status code
             -L, --logging LEVEL              Specify logging mode that results will be returned in. Valid options: light, quiet
@@ -145,13 +146,20 @@ RSpec.describe QuietQuality::Cli::ArgParser do
       expect_options("--light", ["--light"], global: {logging: :light})
       expect_options("-q", ["-q"], global: {logging: :quiet})
       expect_options("--quiet", ["--quiet"], global: {logging: :quiet})
+      expect_options("-n", ["-n"], global: {logging: :normal})
+      expect_options("--normal", ["--normal"], global: {logging: :normal})
+
       expect_options("-lq", ["-lq"], global: {logging: :quiet})
-      expect_options("-ql", ["-ql"], global: {logging: :light})
+      expect_options("-nl", ["-nl"], global: {logging: :light})
+      expect_options("-qn", ["-qn"], global: {logging: :normal})
+
       expect_options("no logging option passed", [], global: {logging: nil})
       expect_options("--logging light", ["--logging", "light"], global: {logging: :light})
       expect_options("-Llight", ["-Llight"], global: {logging: :light})
       expect_options("--logging quiet", ["--logging", "quiet"], global: {logging: :quiet})
       expect_options("-Lquiet", ["-Lquiet"], global: {logging: :quiet})
+      expect_options("--logging normal", ["--logging", "normal"], global: {logging: :normal})
+      expect_options("-Lnormal", ["-Lnormal"], global: {logging: :normal})
       expect_usage_error("-Lshenanigans", ["-Lshenanigans"], /Unrecognized logging level/i)
     end
 

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe QuietQuality::Config::Builder do
 
         context "when global_options[:logging] is unset" do
           let(:global_options) { {} }
-          it { is_expected.to be_nil }
+          it { is_expected.to eq(:normal) }
         end
 
         context "when global_options[:logging] is specified" do

--- a/spec/quiet_quality/config/logging_spec.rb
+++ b/spec/quiet_quality/config/logging_spec.rb
@@ -1,9 +1,16 @@
 RSpec.describe QuietQuality::Config::Logging do
-  describe "#light?" do
-    subject { described_class.new(level: level).light? }
+  subject(:logging) { described_class.new(level: level) }
 
-    context "level is nil" do
-      let(:level) { nil }
+  describe "#light?" do
+    subject { logging.light? }
+
+    context "level is not supplied" do
+      let(:logging) { described_class.new }
+      it { is_expected.to be(false) }
+    end
+
+    context "level is :normal" do
+      let(:level) { described_class::NORMAL }
       it { is_expected.to be(false) }
     end
 
@@ -19,10 +26,15 @@ RSpec.describe QuietQuality::Config::Logging do
   end
 
   describe "#quiet?" do
-    subject { described_class.new(level: level).quiet? }
+    subject { logging.quiet? }
 
-    context "level is nil" do
-      let(:level) { nil }
+    context "level is not supplied" do
+      let(:logging) { described_class.new }
+      it { is_expected.to be(false) }
+    end
+
+    context "level is :normal" do
+      let(:level) { described_class::NORMAL }
       it { is_expected.to be(false) }
     end
 
@@ -41,14 +53,17 @@ RSpec.describe QuietQuality::Config::Logging do
     it "returns the level" do
       expect(described_class.new(level: :light).level).to eq(:light)
       expect(described_class.new(level: :quiet).level).to eq(:quiet)
-      expect(described_class.new.level).to be_nil
+      expect(described_class.new.level).to eq(:normal)
     end
   end
 
   describe "#level=" do
+    let(:level) { described_class::NORMAL }
+
     it "sets the level" do
-      logging = described_class.new
-      expect { logging.level = :light }.to change { logging.level }.from(nil).to(:light)
+      expect { logging.level = :light }
+        .to change { logging.level }
+        .from(:normal).to(:light)
     end
   end
 end

--- a/spec/quiet_quality/config/parser_spec.rb
+++ b/spec/quiet_quality/config/parser_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe QuietQuality::Config::Parser do
         expect_config "no logging", %({}), globals: {comparison_branch: nil}
         expect_config "the valid 'light' logging option", %({logging: "light"}), globals: {logging: :light}
         expect_config "the valid 'quiet' logging option", %({logging: "quiet"}), globals: {logging: :quiet}
+        expect_config "the valid 'normal' logging option", %({logging: "normal"}), globals: {logging: :normal}
         expect_invalid "a numeric logging option", %({logging: 5}), /must be a string/
         expect_invalid "an empty logging option", %({logging: ""}), /option logging must be one of the allowed values/
         expect_invalid "an invalid logging option", %({logging: shecklackity}), /option logging must be one of the allowed values/


### PR DESCRIPTION
The default logging behavior didn't previously have a name, so if you had a configuration file specify `light` or `quiet`, there was no way to put it _back_ afterward on the cli.

This PR replaces the `nil` default value with proper named level `NORMAL`, alongside `LIGHT` and `QUIET`, then updates the arg-parser to support `--normal/-n` (`--logging normal` and `-Lnormal` both worked automatically, as did the config file `logging: normal`. Not that the latter actually has any impact.)

Resolves #92 