### PR TITLE
Allow colorized output (and enable it by default)

### DIFF
--- a/.quiet_quality.ci.yml
+++ b/.quiet_quality.ci.yml
@@ -4,3 +4,4 @@ executor: concurrent
 comparison_branch: origin/main
 all_files: true
 unfiltered: true
+colorize: true

--- a/.quiet_quality.yml
+++ b/.quiet_quality.yml
@@ -5,3 +5,4 @@ comparison_branch: main
 changed_files: false
 filter_messages: false
 logging: light
+colorize: true

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ The configuration file supports the following _global_ options (top-level keys):
   prints a aggregated result (e.g. "3 tools executed: 1 passed, 2 failed
   (rubocop, standardrb)"). The `quiet` option will only return a status code,
   printing nothing.
+* `colorize`: by default, `bin/qq` will include color codes in its output, to
+  make failing tools easier to spot, and messages easier to read. But you can
+  supply `colorize: false` to tell it not to do that if you don't want them.
 
 And then each tool can have an entry, within which `changed_files` and
 `filter_messages` can be specified - the tool-specific settings override the
@@ -196,6 +199,7 @@ Usage: qq [TOOLS] [GLOBAL_OPTIONS] [TOOL_OPTIONS]
     -B, --comparison-branch BRANCH   Specify the branch to compare against
     -f, --filter-messages [tool]     Filter messages from tool(s) based on changed lines
     -u, --unfiltered [tool]          Don't filter messages from tool(s)
+        --[no-]colorize              Colorize the logging output
     -l, --light                      Print aggregated results only
     -q, --quiet                      Don't print results, only return a status code
     -L, --logging LEVEL              Specify logging mode that results will be returned in. Valid options: light, quiet

--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ Usage: qq [TOOLS] [GLOBAL_OPTIONS] [TOOL_OPTIONS]
     -f, --filter-messages [tool]     Filter messages from tool(s) based on changed lines
     -u, --unfiltered [tool]          Don't filter messages from tool(s)
         --[no-]colorize              Colorize the logging output
+    -n, --normal                     Print outcomes and messages
     -l, --light                      Print aggregated results only
     -q, --quiet                      Don't print results, only return a status code
-    -L, --logging LEVEL              Specify logging mode that results will be returned in. Valid options: light, quiet
+    -L, --logging LEVEL              Specify logging mode (from light/quiet/normal)
 ```

--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -65,6 +65,7 @@ module QuietQuality
           setup_annotation_options(parser)
           setup_file_target_options(parser)
           setup_filter_messages_options(parser)
+          setup_colorization_options(parser)
           setup_logging_options(parser)
         end
       end
@@ -133,6 +134,12 @@ module QuietQuality
 
         parser.on("-u", "--unfiltered [tool]", "Don't filter messages from tool(s)") do |tool|
           read_tool_or_global_option(name: :filter_messages, into: :filter_messages, tool: tool, value: false)
+        end
+      end
+
+      def setup_colorization_options(parser)
+        parser.on("--[no-]colorize", "Colorize the logging output") do |value|
+          set_global_option(:colorize, value)
         end
       end
 

--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -156,7 +156,7 @@ module QuietQuality
           set_global_option(:logging, Config::Logging::QUIET)
         end
 
-        parser.on("-L", "--logging LEVEL", "Specify logging mode that results will be returned in. Valid options: light, quiet") do |level|
+        parser.on("-L", "--logging LEVEL", "Specify logging mode (from normal/light/quiet)") do |level|
           validate_value_from("logging level", level, Config::Logging::LEVELS)
           set_global_option(:logging, level.to_sym)
         end

--- a/lib/quiet_quality/config/builder.rb
+++ b/lib/quiet_quality/config/builder.rb
@@ -106,6 +106,7 @@ module QuietQuality
 
         def update_logging
           set_unless_nil(options, :logging, apply.global_option(:logging))
+          set_unless_nil(options, :colorize, apply.global_option(:colorize))
         end
 
         # ---- update the tool options (apply global forms first) -------

--- a/lib/quiet_quality/config/logging.rb
+++ b/lib/quiet_quality/config/logging.rb
@@ -6,10 +6,11 @@ module QuietQuality
       NORMAL = :normal
       LEVELS = [LIGHT, QUIET, NORMAL].freeze
 
-      attr_accessor :level
+      attr_accessor :level, :colorize
 
-      def initialize(level: NORMAL)
+      def initialize(level: NORMAL, colorize: nil)
         @level = level
+        @colorize = colorize
       end
 
       def light?
@@ -18,6 +19,10 @@ module QuietQuality
 
       def quiet?
         @level == QUIET
+      end
+
+      def colorize?
+        @colorize
       end
     end
   end

--- a/lib/quiet_quality/config/logging.rb
+++ b/lib/quiet_quality/config/logging.rb
@@ -8,7 +8,7 @@ module QuietQuality
 
       attr_accessor :level, :colorize
 
-      def initialize(level: NORMAL, colorize: nil)
+      def initialize(level: NORMAL, colorize: true)
         @level = level
         @colorize = colorize
       end

--- a/lib/quiet_quality/config/options.rb
+++ b/lib/quiet_quality/config/options.rb
@@ -15,6 +15,10 @@ module QuietQuality
       def logging=(level)
         @logging.level = level
       end
+
+      def colorize=(value)
+        @logging.colorize = value
+      end
     end
   end
 end

--- a/lib/quiet_quality/config/parsed_options.rb
+++ b/lib/quiet_quality/config/parsed_options.rb
@@ -9,6 +9,7 @@ module QuietQuality
         :annotator,
         :executor,
         :comparison_branch,
+        :colorize,
         :logging,
         :limit_targets,
         :filter_messages,

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -46,6 +46,7 @@ module QuietQuality
         read_global_option(opts, :all_files, :limit_targets, as: :reversed_boolean)
         read_global_option(opts, :filter_messages, :filter_messages, as: :boolean)
         read_global_option(opts, :unfiltered, :filter_messages, as: :reversed_boolean)
+        read_global_option(opts, :colorize, :colorize, as: :boolean)
         read_global_option(opts, :logging, :logging, as: :symbol, validate_from: Logging::LEVELS)
       end
 

--- a/quiet_quality.gemspec
+++ b/quiet_quality.gemspec
@@ -40,6 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.14"
   spec.add_development_dependency "standard", "~> 1.28"
   spec.add_development_dependency "rubocop", "~> 1.50"
-  spec.add_development_dependency "debug"
+  spec.add_development_dependency "debug", "~> 1.7"
   spec.add_development_dependency "mdl", "~> 0.12"
 end

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe QuietQuality::Cli::ArgParser do
             -B, --comparison-branch BRANCH   Specify the branch to compare against
             -f, --filter-messages [tool]     Filter messages from tool(s) based on changed lines
             -u, --unfiltered [tool]          Don't filter messages from tool(s)
+                --[no-]colorize              Colorize the logging output
             -n, --normal                     Print outcomes and messages
             -l, --light                      Print aggregated results only
             -q, --quiet                      Don't print results, only return a status code
@@ -161,6 +162,12 @@ RSpec.describe QuietQuality::Cli::ArgParser do
       expect_options("--logging normal", ["--logging", "normal"], global: {logging: :normal})
       expect_options("-Lnormal", ["-Lnormal"], global: {logging: :normal})
       expect_usage_error("-Lshenanigans", ["-Lshenanigans"], /Unrecognized logging level/i)
+    end
+
+    describe "logging color options" do
+      expect_options("no color options", [], global: {colorize: nil})
+      expect_options("--colorize", ["--colorize"], global: {colorize: true})
+      expect_options("--no-colorize", ["--no-colorize"], global: {colorize: false})
     end
 
     describe "file targeting options" do

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe QuietQuality::Cli::ArgParser do
             -n, --normal                     Print outcomes and messages
             -l, --light                      Print aggregated results only
             -q, --quiet                      Don't print results, only return a status code
-            -L, --logging LEVEL              Specify logging mode that results will be returned in. Valid options: light, quiet
+            -L, --logging LEVEL              Specify logging mode (from normal/light/quiet)
       HELP_OUTPUT
     end
   end

--- a/spec/quiet_quality/cli/presenter_spec.rb
+++ b/spec/quiet_quality/cli/presenter_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe QuietQuality::Cli::Presenter do
   let(:logger) { instance_double(QuietQuality::Logger, puts: nil) }
   let(:level) { nil }
-  let(:logging) { QuietQuality::Config::Logging.new(level: level) }
+  let(:colorize) { false }
+  let(:logging) { QuietQuality::Config::Logging.new(level: level, colorize: colorize) }
 
   let(:rspec_outcome) { build_success(:rspec, "rspec output", "rspec logging") }
   let(:haml_lint_outcome) { build_failure(:haml_lint, "haml_lint output", "haml_lint logging") }
@@ -28,23 +29,54 @@ RSpec.describe QuietQuality::Cli::Presenter do
     context "when logging.light?" do
       let(:level) { QuietQuality::Config::Logging::LIGHT }
 
-      it "writes a one-line output" do
-        log_results
-        expect(logger).to have_received(:puts).once
-          .with("2 tools executed: 1 passed, 1 failed (haml_lint)")
+      context "with colorization disabled" do
+        let(:colorize) { false }
+
+        it "writes a one-line output" do
+          log_results
+          expect(logger).to have_received(:puts).once
+            .with("2 tools executed: 1 passed, 1 failed (haml_lint)")
+        end
+      end
+
+      context "with colorization enabled" do
+        let(:colorize) { true }
+
+        it "writes a one-line output" do
+          log_results
+          expect(logger).to have_received(:puts).once
+            .with("2 tools executed: 1 passed, 1 failed\e[31m (haml_lint)\e[0m")
+        end
       end
     end
 
     context "when logging normally" do
       let(:level) { nil }
 
-      it "writes standard output" do
-        log_results
-        expect(logger).to have_received(:puts).with("--- Passed: rspec").ordered
-        expect(logger).to have_received(:puts).with("--- Failed: haml_lint").ordered
-        expect(logger).to have_received(:puts).with("\n\n2 messages:").ordered
-        expect(logger).to have_received(:puts).with("ai_fixes_ur_code  foo.rb:55  [foorule]  foo\\nbody").ordered
-        expect(logger).to have_received(:puts).with("sudo_make_me_a_sandwhich  bar.rb:8-14  [barule]  barbody" + "x" * 113).ordered
+      context "with colorization disabled" do
+        let(:colorize) { false }
+
+        it "writes standard output" do
+          log_results
+          expect(logger).to have_received(:puts).with("--- Passed: rspec").ordered
+          expect(logger).to have_received(:puts).with("--- Failed: haml_lint").ordered
+          expect(logger).to have_received(:puts).with("\n\n2 messages:").ordered
+          expect(logger).to have_received(:puts).with("ai_fixes_ur_code  foo.rb:55  [foorule]  foo\\nbody").ordered
+          expect(logger).to have_received(:puts).with("sudo_make_me_a_sandwhich  bar.rb:8-14  [barule]  barbody" + "x" * 113).ordered
+        end
+      end
+
+      context "with colorization enabled" do
+        let(:colorize) { true }
+
+        it "writes standard output" do
+          log_results
+          expect(logger).to have_received(:puts).with("--- \e[32mPassed: rspec\e[0m").ordered
+          expect(logger).to have_received(:puts).with("--- \e[31mFailed: haml_lint\e[0m").ordered
+          expect(logger).to have_received(:puts).with("\n\n2 messages:").ordered
+          expect(logger).to have_received(:puts).with("\e[33mai_fixes_ur_code\e[0m  foo.rb:55  [\e[33mfoorule\e[0m]  foo\\nbody").ordered
+          expect(logger).to have_received(:puts).with("\e[33msudo_make_me_a_sandwhich\e[0m  bar.rb:8-14  [\e[33mbarule\e[0m]  barbody" + "x" * 113).ordered
+        end
       end
     end
   end

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -152,28 +152,33 @@ RSpec.describe QuietQuality::Config::Builder do
 
         context "when global_options[:colorize] is unset" do
           let(:global_options) { {} }
-          it { is_expected.to be_nil }
+          it { is_expected.to be_truthy }
         end
 
-        context "when global_options[:colorize] is specified" do
+        context "when global_options[:colorize] is specified as true" do
           let(:global_options) { {colorize: true} }
           it { is_expected.to be_truthy }
+        end
+
+        context "when global_options[:colorize] is specified as false" do
+          let(:global_options) { {colorize: false} }
+          it { is_expected.to be_falsey }
         end
 
         context "when a config file is passed" do
           let(:global_options) { {config_path: "/fake.yml", colorize: cli_colorize}.compact }
 
           context "when the config file sets colorize" do
-            let(:cfg_global_options) { {colorize: true} }
+            let(:cfg_global_options) { {colorize: false} }
 
             context "and the cli does not" do
               let(:cli_colorize) { nil }
-              it { is_expected.to be_truthy }
+              it { is_expected.to be_falsey }
             end
 
             context "and the cli sets it differently" do
-              let(:cli_colorize) { false }
-              it { is_expected.to be_falsey }
+              let(:cli_colorize) { true }
+              it { is_expected.to be_truthy }
             end
           end
         end

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -113,32 +113,68 @@ RSpec.describe QuietQuality::Config::Builder do
     end
 
     describe "#logging" do
-      subject(:logging) { options.logging.level }
+      subject(:logging) { options.logging }
 
-      context "when global_options[:logging] is unset" do
-        let(:global_options) { {} }
-        it { is_expected.to eq(:normal) }
-      end
+      describe "#level" do
+        subject(:level) { logging.level }
 
-      context "when global_options[:logging] is specified" do
-        let(:global_options) { {logging: :quiet} }
-        it { is_expected.to eq(:quiet) }
-      end
+        context "when global_options[:logging] is unset" do
+          let(:global_options) { {} }
+          it { is_expected.to eq(:normal) }
+        end
 
-      context "when a config file is passed" do
-        let(:global_options) { {config_path: "/fake.yml", logging: cli_logging} }
+        context "when global_options[:logging] is specified" do
+          let(:global_options) { {logging: :quiet} }
+          it { is_expected.to eq(:quiet) }
+        end
 
-        context "when the config file sets the logging" do
-          let(:cfg_global_options) { {logging: :light} }
+        context "when a config file is passed" do
+          let(:global_options) { {config_path: "/fake.yml", logging: cli_logging} }
 
-          context "and the cli does not" do
-            let(:cli_logging) { nil }
-            it { is_expected.to eq(:light) }
+          context "when the config file sets the logging" do
+            let(:cfg_global_options) { {logging: :light} }
+
+            context "and the cli does not" do
+              let(:cli_logging) { nil }
+              it { is_expected.to eq(:light) }
+            end
+
+            context "and the cli sets a different one" do
+              let(:cli_logging) { :quiet }
+              it { is_expected.to eq(:quiet) }
+            end
           end
+        end
+      end
 
-          context "and the cli sets a different one" do
-            let(:cli_logging) { :quiet }
-            it { is_expected.to eq(:quiet) }
+      describe "#colorize" do
+        subject(:colorize?) { logging.colorize? }
+
+        context "when global_options[:colorize] is unset" do
+          let(:global_options) { {} }
+          it { is_expected.to be_nil }
+        end
+
+        context "when global_options[:colorize] is specified" do
+          let(:global_options) { {colorize: true} }
+          it { is_expected.to be_truthy }
+        end
+
+        context "when a config file is passed" do
+          let(:global_options) { {config_path: "/fake.yml", colorize: cli_colorize}.compact }
+
+          context "when the config file sets colorize" do
+            let(:cfg_global_options) { {colorize: true} }
+
+            context "and the cli does not" do
+              let(:cli_colorize) { nil }
+              it { is_expected.to be_truthy }
+            end
+
+            context "and the cli sets it differently" do
+              let(:cli_colorize) { false }
+              it { is_expected.to be_falsey }
+            end
           end
         end
       end

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -112,6 +112,38 @@ RSpec.describe QuietQuality::Config::Builder do
       end
     end
 
+    describe "#logging" do
+      subject(:logging) { options.logging.level }
+
+      context "when global_options[:logging] is unset" do
+        let(:global_options) { {} }
+        it { is_expected.to eq(:normal) }
+      end
+
+      context "when global_options[:logging] is specified" do
+        let(:global_options) { {logging: :quiet} }
+        it { is_expected.to eq(:quiet) }
+      end
+
+      context "when a config file is passed" do
+        let(:global_options) { {config_path: "/fake.yml", logging: cli_logging} }
+
+        context "when the config file sets the logging" do
+          let(:cfg_global_options) { {logging: :light} }
+
+          context "and the cli does not" do
+            let(:cli_logging) { nil }
+            it { is_expected.to eq(:light) }
+          end
+
+          context "and the cli sets a different one" do
+            let(:cli_logging) { :quiet }
+            it { is_expected.to eq(:quiet) }
+          end
+        end
+      end
+    end
+
     describe "#tools" do
       subject(:tools) { options.tools }
 
@@ -250,38 +282,6 @@ RSpec.describe QuietQuality::Config::Builder do
             context "but the cli specifically disables it" do
               let(:tool_options) { {rspec: {filter_messages: false}} }
               it { is_expected.to be_falsey }
-            end
-          end
-        end
-      end
-
-      describe "#logging" do
-        subject(:logging) { options.logging.level }
-
-        context "when global_options[:logging] is unset" do
-          let(:global_options) { {} }
-          it { is_expected.to eq(:normal) }
-        end
-
-        context "when global_options[:logging] is specified" do
-          let(:global_options) { {logging: :quiet} }
-          it { is_expected.to eq(:quiet) }
-        end
-
-        context "when a config file is passed" do
-          let(:global_options) { {config_path: "/fake.yml", logging: cli_logging} }
-
-          context "when the config file sets the logging" do
-            let(:cfg_global_options) { {logging: :light} }
-
-            context "and the cli does not" do
-              let(:cli_logging) { nil }
-              it { is_expected.to eq(:light) }
-            end
-
-            context "and the cli sets a different one" do
-              let(:cli_logging) { :quiet }
-              it { is_expected.to eq(:quiet) }
             end
           end
         end

--- a/spec/quiet_quality/config/logging_spec.rb
+++ b/spec/quiet_quality/config/logging_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe QuietQuality::Config::Logging do
   let(:level) { described_class::NORMAL }
-  let(:colorize) { nil }
+  let(:colorize) { true }
   subject(:logging) { described_class.new(level: level, colorize: colorize) }
 
   describe "#light?" do
@@ -74,17 +74,23 @@ RSpec.describe QuietQuality::Config::Logging do
 
     context "when not supplied" do
       let(:logging) { described_class.new }
+      it { is_expected.to be_truthy }
+    end
+
+    context "when supplied as false" do
+      let(:colorize) { false }
       it { is_expected.to be_falsey }
     end
 
-    context "when supplied" do
+    context "when supplied as true" do
       let(:colorize) { true }
       it { is_expected.to be_truthy }
     end
 
-    context "when set after creation" do
-      before { logging.colorize = true }
-      it { is_expected.to be_truthy }
+    it "can be changed after creation" do
+      expect { logging.colorize = false }
+        .to change { logging.colorize? }
+        .from(true).to(false)
     end
   end
 end

--- a/spec/quiet_quality/config/logging_spec.rb
+++ b/spec/quiet_quality/config/logging_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe QuietQuality::Config::Logging do
-  subject(:logging) { described_class.new(level: level) }
+  let(:level) { described_class::NORMAL }
+  let(:colorize) { nil }
+  subject(:logging) { described_class.new(level: level, colorize: colorize) }
 
   describe "#light?" do
     subject { logging.light? }
@@ -64,6 +66,25 @@ RSpec.describe QuietQuality::Config::Logging do
       expect { logging.level = :light }
         .to change { logging.level }
         .from(:normal).to(:light)
+    end
+  end
+
+  describe "#colorize?" do
+    subject(:colorize?) { logging.colorize? }
+
+    context "when not supplied" do
+      let(:logging) { described_class.new }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when supplied" do
+      let(:colorize) { true }
+      it { is_expected.to be_truthy }
+    end
+
+    context "when set after creation" do
+      before { logging.colorize = true }
+      it { is_expected.to be_truthy }
     end
   end
 end

--- a/spec/quiet_quality/config/options_spec.rb
+++ b/spec/quiet_quality/config/options_spec.rb
@@ -20,4 +20,11 @@ RSpec.describe QuietQuality::Config::Options do
       expect(options.logging.light?).to be true
     end
   end
+
+  describe "#colorize=" do
+    it "sets the logging colorization" do
+      options.colorize = true
+      expect(options.logging.colorize?).to be true
+    end
+  end
 end

--- a/spec/quiet_quality/config/parser_spec.rb
+++ b/spec/quiet_quality/config/parser_spec.rb
@@ -132,13 +132,15 @@ RSpec.describe QuietQuality::Config::Parser do
       end
 
       describe "logging parsing" do
-        expect_config "no logging", %({}), globals: {comparison_branch: nil}
+        expect_config "no logging", %({}), globals: {comparison_branch: nil, colorize: nil}
         expect_config "the valid 'light' logging option", %({logging: "light"}), globals: {logging: :light}
         expect_config "the valid 'quiet' logging option", %({logging: "quiet"}), globals: {logging: :quiet}
         expect_config "the valid 'normal' logging option", %({logging: "normal"}), globals: {logging: :normal}
         expect_invalid "a numeric logging option", %({logging: 5}), /must be a string/
         expect_invalid "an empty logging option", %({logging: ""}), /option logging must be one of the allowed values/
         expect_invalid "an invalid logging option", %({logging: shecklackity}), /option logging must be one of the allowed values/
+        expect_config "colorization enabled", %({colorize: true}), globals: {colorize: true}
+        expect_config "colorization disabled", %({colorize: false}), globals: {colorize: false}
       end
 
       describe "file_filter parsing" do


### PR DESCRIPTION
When executing tools, seeing that they all passed (or which ones failed) at a glance is valuable, and colors mostly help us do that efficiently (if anyone is red-green colorblind and has some accessibility suggestions, I'd welcome those, but I suspect the most important thing is that we do not convey _any_ information _solely_ through color, which I definitely don't intend to do).

The old "light" output vs new:
<img width="459" alt="Screen Shot 2023-06-04 at 2 14 22 PM" src="https://github.com/nevinera/quiet_quality/assets/366133/c7944393-07ad-4cd2-9a3b-9ea0e08a2f81">

And the old 'normal' output vs new:
<img width="1213" alt="Screen Shot 2023-06-04 at 2 15 19 PM" src="https://github.com/nevinera/quiet_quality/assets/366133/dbf1a682-5380-4d41-88db-724a6b941f9d">

Resolves #36 