### PR TITLE
Add the Logger system and Logging module

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,4 +204,5 @@ Usage: qq [TOOLS] [GLOBAL_OPTIONS] [TOOL_OPTIONS]
     -l, --light                      Print aggregated results only
     -q, --quiet                      Don't print results, only return a status code
     -L, --logging LEVEL              Specify logging mode (from light/quiet/normal)
+    -v, --verbose                    Log more verbosely - multiple times is more verbose
 ```

--- a/lib/quiet_quality.rb
+++ b/lib/quiet_quality.rb
@@ -17,5 +17,6 @@ module QuietQuality
 end
 
 require_relative "./quiet_quality/logger"
+require_relative "./quiet_quality/logging"
 glob = File.expand_path("../quiet_quality/*.rb", __FILE__)
 Dir.glob(glob).sort.each { |f| require f }

--- a/lib/quiet_quality.rb
+++ b/lib/quiet_quality.rb
@@ -10,7 +10,12 @@ require "set" # rubocop:disable Lint/RedundantRequireStatement
 
 module QuietQuality
   Error = Class.new(StandardError)
+
+  def self.logger
+    @_logger ||= QuietQuality::Logger.new
+  end
 end
 
+require_relative "./quiet_quality/logger"
 glob = File.expand_path("../quiet_quality/*.rb", __FILE__)
 Dir.glob(glob).sort.each { |f| require f }

--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -67,6 +67,7 @@ module QuietQuality
           setup_filter_messages_options(parser)
           setup_colorization_options(parser)
           setup_logging_options(parser)
+          setup_verbosity_options(parser)
         end
       end
 
@@ -159,6 +160,12 @@ module QuietQuality
         parser.on("-L", "--logging LEVEL", "Specify logging mode (from normal/light/quiet)") do |level|
           validate_value_from("logging level", level.to_sym, Config::Options::LOGGING_LEVELS)
           set_global_option(:logging, level.to_sym)
+        end
+      end
+
+      def setup_verbosity_options(parser)
+        parser.on("-v", "--verbose", "Log more verbosely - multiple times is more verbose") do
+          QuietQuality.logger.increase_level!
         end
       end
     end

--- a/lib/quiet_quality/cli/entrypoint.rb
+++ b/lib/quiet_quality/cli/entrypoint.rb
@@ -1,6 +1,8 @@
 module QuietQuality
   module Cli
     class Entrypoint
+      include Logging
+
       def initialize(argv:, output_stream: $stdout, error_stream: $stderr)
         @argv = argv
         @output_stream = output_stream
@@ -15,6 +17,7 @@ module QuietQuality
         elsif no_tools?
           log_no_tools_text
         else
+          log_options
           executed
           log_results
           annotate_messages
@@ -40,6 +43,10 @@ module QuietQuality
           outcomes: executor.outcomes,
           messages: executor.messages
         )
+      end
+
+      def log_options
+        debug("Complete Options object:", data: options.to_h)
       end
 
       def log_results
@@ -109,6 +116,7 @@ module QuietQuality
 
       def annotate_messages
         return unless options.annotator
+        info("Annotating with #{options.annotator}")
         annotator = options.annotator.new(output_stream: output_stream)
         annotator.annotate!(executed.messages)
       end

--- a/lib/quiet_quality/cli/presenter.rb
+++ b/lib/quiet_quality/cli/presenter.rb
@@ -1,8 +1,6 @@
 module QuietQuality
   module Cli
     class Presenter
-      COLORS = {red: 31, green: 32, yellow: 33}.freeze
-
       def initialize(stream:, options:, outcomes:, messages:)
         @stream = stream
         @options = options
@@ -33,10 +31,9 @@ module QuietQuality
         @_successful_outcomes ||= outcomes.select(&:success?)
       end
 
-      def colorize(color, s)
+      def colorize(color_name, s)
         return s unless options.colorize?
-        color_code = COLORS.fetch(color)
-        "\e[#{color_code}m#{s}\e[0m"
+        Colorize.colorize(s, color: color_name)
       end
 
       def failed_tools_text

--- a/lib/quiet_quality/colorize.rb
+++ b/lib/quiet_quality/colorize.rb
@@ -1,0 +1,19 @@
+module QuietQuality
+  module Colorize
+    CODES = {
+      red: "\e[31m",
+      green: "\e[32m",
+      yellow: "\e[33m",
+      light_blue: "\e[94m",
+      light_cyan: "\e[96m"
+    }.freeze
+
+    RESET_CODE = "\e[0m"
+
+    def self.colorize(s, color:)
+      fail(ArgumentError, "Unrecognized color '#{color}'") unless CODES.include?(color.to_sym)
+      color_code = CODES.fetch(color.to_sym)
+      "#{color_code}#{s}#{RESET_CODE}"
+    end
+  end
+end

--- a/lib/quiet_quality/config/options.rb
+++ b/lib/quiet_quality/config/options.rb
@@ -32,6 +32,26 @@ module QuietQuality
       def light?
         logging == :light
       end
+
+      def to_h
+        {
+          annotator: annotator,
+          executor: executor.name,
+          comparison_branch: comparison_branch,
+          colorize: colorize?,
+          logging: logging,
+          tools: tool_hashes_by_name
+        }
+      end
+
+      private
+
+      def tool_hashes_by_name
+        return {} unless tools
+        tools
+          .map { |tool_option| [tool_option.tool_name, tool_option.to_h] }
+          .to_h
+      end
     end
   end
 end

--- a/lib/quiet_quality/config/tool_options.rb
+++ b/lib/quiet_quality/config/tool_options.rb
@@ -35,6 +35,15 @@ module QuietQuality
         return nil if @file_filter.nil?
         Regexp.new(@file_filter)
       end
+
+      def to_h
+        {
+          tool_name: tool_name,
+          limit_targets: limit_targets?,
+          filter_messages: filter_messages?,
+          file_filter: file_filter&.to_s
+        }
+      end
     end
   end
 end

--- a/lib/quiet_quality/executors/pipeline.rb
+++ b/lib/quiet_quality/executors/pipeline.rb
@@ -1,6 +1,8 @@
 module QuietQuality
   module Executors
     class Pipeline
+      include Logging
+
       def initialize(tool_options:, changed_files: nil)
         @tool_options = tool_options
         @changed_files = changed_files
@@ -51,7 +53,12 @@ module QuietQuality
         @_runner ||= tool_options.runner_class.new(
           changed_files: limit_targets? ? changed_files : nil,
           file_filter: tool_options.file_filter
-        )
+        ).tap { |r| log_runner(r) }
+      end
+
+      def log_runner(r)
+        info("Runner #{r.tool_name} command: `#{r.command.join(" ")}`")
+        debug("Full command for #{r.tool_name}", data: r.command)
       end
 
       def parser

--- a/lib/quiet_quality/logger.rb
+++ b/lib/quiet_quality/logger.rb
@@ -1,0 +1,65 @@
+module QuietQuality
+  class Logger
+    LEVEL_UPS = {none: :warn, warn: :info, info: :debug}.freeze
+    LEVELS = {none: 0, warn: 1, info: 2, debug: 3}.freeze
+    COLORS = {warn: :yellow, info: :light_blue, debug: :light_cyan}.freeze
+
+    def initialize(level: :warn, stream: $stderr)
+      @level = level
+      @stream = stream
+    end
+
+    attr_reader :level
+
+    def increase_level!
+      next_level = LEVEL_UPS.fetch(level, nil)
+      self.level = next_level if next_level
+    end
+
+    def show?(message_level)
+      LEVELS[message_level] <= LEVELS[level]
+    end
+
+    def level=(name)
+      fail(ArgumentError, "Unrecognized Logger level '#{name}'") unless LEVELS.include?(name.to_sym)
+      @level = name.to_sym
+    end
+
+    def warn(message, data: nil)
+      log_message(message, data, :warn)
+    end
+
+    def info(message, data: nil)
+      log_message(message, data, :info)
+    end
+
+    def debug(message, data: nil)
+      log_message(message, data, :debug)
+    end
+
+    private
+
+    attr_reader :stream
+
+    def log_message(message, data, message_level)
+      return unless show?(message_level)
+      stream.puts formatted_message(message, data, message_level)
+      stream.flush
+    end
+
+    def formatted_message(message, data, message_level)
+      prefix = message_level.to_s.upcase.rjust(5)
+      if data
+        data_text = JSON.pretty_generate(data)
+        message = message + "\n" + data_text
+      end
+      prefixed_message = message.split("\n").map { |line| "[#{prefix}] #{line}" }.join("\n")
+      colorize(prefixed_message, message_level)
+    end
+
+    def colorize(s, message_level)
+      color = COLORS.fetch(message_level)
+      Colorize.colorize(s, color: color)
+    end
+  end
+end

--- a/lib/quiet_quality/logging.rb
+++ b/lib/quiet_quality/logging.rb
@@ -1,0 +1,21 @@
+module QuietQuality
+  module Logging
+    def warn(message, data: nil)
+      logger.warn(message, data: data)
+    end
+
+    def info(message, data: nil)
+      logger.info(message, data: data)
+    end
+
+    def debug(message, data: nil)
+      logger.debug(message, data: data)
+    end
+
+    private
+
+    def logger
+      QuietQuality.logger
+    end
+  end
+end

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe QuietQuality::Cli::ArgParser do
             -l, --light                      Print aggregated results only
             -q, --quiet                      Don't print results, only return a status code
             -L, --logging LEVEL              Specify logging mode (from normal/light/quiet)
+            -v, --verbose                    Log more verbosely - multiple times is more verbose
       HELP_OUTPUT
     end
   end
@@ -214,6 +215,46 @@ RSpec.describe QuietQuality::Cli::ArgParser do
       expect_usage_error("-ffooba", ["-ffooba"], /Unrecognized tool/)
       expect_usage_error("--unfiltered fooba", ["--unfiltered", "fooba"], /Unrecognized tool/)
       expect_usage_error("-ufooba", ["-ufooba"], /Unrecognized tool/)
+    end
+  end
+
+  describe "verbosity options" do
+    let(:logger) { QuietQuality.logger }
+
+    context "with no arguments" do
+      let(:args) { [] }
+
+      it "does not increase the verbosity level" do
+        parsed
+        expect(logger).not_to have_received(:increase_level!)
+      end
+    end
+
+    context "with -v passed" do
+      let(:args) { ["-v"] }
+
+      it "increases verbosity once" do
+        parsed
+        expect(logger).to have_received(:increase_level!).once
+      end
+    end
+
+    context "with -v passed twice" do
+      let(:args) { ["-vv"] }
+
+      it "increases verbosity twice" do
+        parsed
+        expect(logger).to have_received(:increase_level!).twice
+      end
+    end
+
+    context "with -v passed alongside --verbose" do
+      let(:args) { ["-v", "--verbose"] }
+
+      it "increases verbosity twice" do
+        parsed
+        expect(logger).to have_received(:increase_level!).twice
+      end
     end
   end
 end

--- a/spec/quiet_quality/cli/entrypoint_spec.rb
+++ b/spec/quiet_quality/cli/entrypoint_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
   describe "#execute" do
     subject(:execute) { entrypoint.execute }
 
+    it "logs the options (at debug level)" do
+      execute
+      expect_debug("Complete Options object:", data: options.to_h)
+    end
+
     context "when the tools all pass" do
       let(:messages) { empty_messages }
       let(:outcomes) { [build_success(:rspec), build_success(:rubocop)] }

--- a/spec/quiet_quality/colorize_spec.rb
+++ b/spec/quiet_quality/colorize_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe QuietQuality::Colorize do
+  describe ".colorize" do
+    def self.it_colorizes(text, with:, as:)
+      it "colors text #{with} properly" do
+        expect(described_class.colorize(text, color: with)).to eq(as)
+      end
+    end
+
+    it_colorizes "hello", with: :red, as: "\e[31mhello\e[0m"
+    it_colorizes "hello", with: :green, as: "\e[32mhello\e[0m"
+    it_colorizes "hello", with: "yellow", as: "\e[33mhello\e[0m"
+    it_colorizes "hello", with: "light_blue", as: "\e[94mhello\e[0m"
+    it_colorizes "hello", with: :light_cyan, as: "\e[96mhello\e[0m"
+
+    it "raises an ArgumentError for an unrecognized color" do
+      expect { described_class.colorize("hello", color: :tangerine) }
+        .to raise_error(ArgumentError, /Unrecognized color 'tangerine'/)
+    end
+  end
+end

--- a/spec/quiet_quality/config/options_spec.rb
+++ b/spec/quiet_quality/config/options_spec.rb
@@ -75,4 +75,33 @@ RSpec.describe QuietQuality::Config::Options do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe "#to_h" do
+    let(:options) { build_options(colorize: true, rspec: {limit_targets: true}, standardrb: {filter_messages: false}) }
+    subject(:to_h) { options.to_h }
+
+    it "produces the expected data" do
+      expect(to_h).to eq({
+        annotator: nil,
+        colorize: true,
+        comparison_branch: nil,
+        executor: "QuietQuality::Executors::ConcurrentExecutor",
+        logging: :normal,
+        tools: {
+          rspec: {
+            tool_name: :rspec,
+            file_filter: nil,
+            filter_messages: true,
+            limit_targets: true
+          },
+          standardrb: {
+            tool_name: :standardrb,
+            file_filter: nil,
+            filter_messages: false,
+            limit_targets: true
+          }
+        }
+      })
+    end
+  end
 end

--- a/spec/quiet_quality/config/tool_options_spec.rb
+++ b/spec/quiet_quality/config/tool_options_spec.rb
@@ -55,4 +55,34 @@ RSpec.describe QuietQuality::Config::ToolOptions do
     include_examples "exposes the expected constants for", :rubocop, QuietQuality::Tools::Rubocop
     include_examples "exposes the expected constants for", :standardrb, QuietQuality::Tools::Standardrb
   end
+
+  describe "#to_h" do
+    subject(:to_h) { tool_options.to_h }
+
+    context "with all attributes supplied" do
+      let(:tool_options) { described_class.new(:rspec, limit_targets: true, filter_messages: false, file_filter: /^foo.*$/i) }
+
+      it "produces the expected hash" do
+        expect(to_h).to eq({
+          tool_name: :rspec,
+          limit_targets: true,
+          filter_messages: false,
+          file_filter: "(?i-mx:^foo.*$)"
+        })
+      end
+    end
+
+    context "with some attributes not specified" do
+      let(:tool_options) { described_class.new(:standardrb, filter_messages: false) }
+
+      it "produces the expected hash" do
+        expect(to_h).to eq({
+          tool_name: :standardrb,
+          limit_targets: true,
+          filter_messages: false,
+          file_filter: nil
+        })
+      end
+    end
+  end
 end

--- a/spec/quiet_quality/executors/pipeline_spec.rb
+++ b/spec/quiet_quality/executors/pipeline_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe QuietQuality::Executors::Pipeline do
 
   let(:runner_outcome) { build_failure(tool_name, "fake output", "fake logging") }
   let(:runner_class) { QuietQuality::Tools::Rspec::Runner }
-  let(:runner) { instance_double(runner_class, invoke!: runner_outcome) }
+  let(:runner) { instance_double(runner_class, invoke!: runner_outcome, tool_name: :rspec, command: ["foo", "bar"]) }
   before { allow(runner_class).to receive(:new).and_return(runner) }
 
   let(:other_messages) { generate_messages(4, path: "path/other.rb") }
@@ -30,6 +30,12 @@ RSpec.describe QuietQuality::Executors::Pipeline do
 
   describe "#outcome" do
     subject(:outcome) { pipeline.outcome }
+
+    it "logs the runner command" do
+      outcome
+      expect_info("Runner rspec command: `foo bar`")
+      expect_debug("Full command for rspec", data: ["foo", "bar"])
+    end
 
     context "when targets are to be limited" do
       let(:limit_targets?) { true }

--- a/spec/quiet_quality/logger_spec.rb
+++ b/spec/quiet_quality/logger_spec.rb
@@ -1,0 +1,166 @@
+RSpec.describe QuietQuality::Logger do
+  let(:initial_level) { :warn }
+  let(:stream) { instance_double(IO, puts: nil, flush: nil) }
+  subject(:logger) { described_class.new(level: initial_level, stream: stream) }
+
+  describe "#level" do
+    subject(:level) { logger.level }
+
+    def self.it_shows(level, can_show = true)
+      it "will display log messages with level #{level}" do
+        if can_show
+          expect(logger.show?(level)).to be_truthy
+        else
+          expect(logger.show?(level)).to be_falsey
+        end
+      end
+    end
+
+    context "by default" do
+      let(:logger) { described_class.new }
+      it { is_expected.to eq(:warn) }
+      it_shows(:warn)
+      it_shows(:info, false)
+      it_shows(:debug, false)
+
+      it "can be increased from warn to info" do
+        expect { logger.increase_level! }.to change(logger, :level).from(:warn).to(:info)
+      end
+    end
+
+    context "after being set to :none" do
+      before { logger.level = :none }
+      it { is_expected.to eq(:none) }
+      it_shows(:warn, false)
+      it_shows(:info, false)
+      it_shows(:debug, false)
+
+      it "can be increased from none to warn" do
+        expect { logger.increase_level! }.to change(logger, :level).from(:none).to(:warn)
+      end
+    end
+
+    context "after being set to :info" do
+      before { logger.level = :info }
+      it { is_expected.to eq(:info) }
+      it_shows(:warn)
+      it_shows(:info)
+      it_shows(:debug, false)
+
+      it "can be increased from info to debug" do
+        expect { logger.increase_level! }.to change(logger, :level).from(:info).to(:debug)
+      end
+    end
+
+    context "after being set to :debug" do
+      before { logger.level = :debug }
+      it { is_expected.to eq(:debug) }
+      it_shows(:warn)
+      it_shows(:info)
+      it_shows(:debug)
+
+      it "can be increased, but it stays as :debug" do
+        expect { logger.increase_level! }.not_to change(logger, :level).from(:debug)
+      end
+    end
+  end
+
+  def self.it_logs_nothing
+    it "does not log anything" do
+      subject
+      expect(stream).not_to have_received(:puts)
+    end
+
+    context "when data is supplied" do
+      let(:data) { {some: "data"} }
+
+      it "does not log anything" do
+        subject
+        expect(stream).not_to have_received(:puts)
+      end
+    end
+  end
+
+  def self.it_logs(message, data: nil)
+    context(data ? "with data supplied" : "without data supplied") do
+      let(:data) { data }
+
+      it "logs the expected message" do
+        subject
+        expect(stream).to have_received(:puts).with(message)
+        expect(stream).to have_received(:flush)
+      end
+    end
+  end
+
+  describe "#warn" do
+    let(:data) { nil }
+    subject(:warn) { logger.warn("some text", data: data) }
+
+    context "when logging level is :none" do
+      let(:initial_level) { :none }
+      it_logs_nothing
+    end
+
+    [:warn, :info, :debug].each do |iterated_level|
+      context "when logging level is :#{iterated_level}" do
+        let(:initial_level) { iterated_level }
+        it_logs("\e[33m[ WARN] some text\e[0m")
+        it_logs(<<~LOGS.strip, data: {some: "data"})
+          \e[33m[ WARN] some text
+          [ WARN] {
+          [ WARN]   "some": "data"
+          [ WARN] }\e[0m
+        LOGS
+      end
+    end
+  end
+
+  describe "#info" do
+    let(:data) { nil }
+    subject(:info) { logger.info("some text", data: data) }
+
+    [:none, :warn].each do |iterated_level|
+      context "when logging level is :#{iterated_level}" do
+        let(:initial_level) { iterated_level }
+        it_logs_nothing
+      end
+    end
+
+    [:info, :debug].each do |iterated_level|
+      context "when logging level is :#{iterated_level}" do
+        let(:initial_level) { iterated_level }
+        it_logs("\e[94m[ INFO] some text\e[0m")
+        it_logs(<<~LOGS.strip, data: {some: "data"})
+          \e[94m[ INFO] some text
+          [ INFO] {
+          [ INFO]   "some": "data"
+          [ INFO] }\e[0m
+        LOGS
+      end
+    end
+  end
+
+  describe "#debug" do
+    let(:data) { nil }
+    subject(:debug) { logger.debug("some text", data: data) }
+
+    [:none, :warn, :info].each do |iterated_level|
+      context "when logging level is :#{iterated_level}" do
+        let(:initial_level) { iterated_level }
+        it_logs_nothing
+      end
+    end
+
+    context "when logging level is :debug" do
+      let(:initial_level) { :debug }
+      it_logs("\e[96m[DEBUG] some text\e[0m")
+      it_logs(<<~LOGS.strip, data: {some: "data"})
+        \e[96m[DEBUG] some text
+        [DEBUG] {
+        [DEBUG]   "some": "data"
+        [DEBUG] }\e[0m
+      LOGS
+    end
+  end
+end

--- a/spec/quiet_quality/logging_spec.rb
+++ b/spec/quiet_quality/logging_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe QuietQuality::Logging do
+  let(:including_class) do
+    Class.new do
+      include QuietQuality::Logging
+    end
+  end
+
+  subject(:logging_instance) { including_class.new }
+
+  describe "#warn" do
+    it "calls the central logger" do
+      logging_instance.warn("some text", data: {some: "data"})
+      expect(QuietQuality.logger).to have_received(:warn).with("some text", data: {some: "data"})
+    end
+  end
+
+  describe "#info" do
+    it "calls the central logger" do
+      logging_instance.info("some text", data: {some: "data"})
+      expect(QuietQuality.logger).to have_received(:info).with("some text", data: {some: "data"})
+    end
+  end
+
+  describe "#debug" do
+    it "calls the central logger" do
+      logging_instance.debug("some text", data: {some: "data"})
+      expect(QuietQuality.logger).to have_received(:debug).with("some text", data: {some: "data"})
+    end
+  end
+end

--- a/spec/quiet_quality_spec.rb
+++ b/spec/quiet_quality_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe QuietQuality do
+  describe ".logger" do
+    subject(:logger) { described_class.logger }
+    it { is_expected.to be_a(QuietQuality::Logger) }
+
+    it "is memoized" do
+      logger_one = QuietQuality.logger
+      logger_two = QuietQuality.logger
+      expect(logger_one.object_id).to eq(logger_two.object_id)
+    end
+  end
+end

--- a/spec/support/logger_mocking.rb
+++ b/spec/support/logger_mocking.rb
@@ -1,0 +1,28 @@
+module LoggerMocking
+  def expect_logged(level, message, data: nil)
+    expect(QuietQuality.logger).to have_received(level).with(message, data: data)
+  end
+
+  def expect_warn(message, data: nil)
+    expect_logged(:warn, message, data: data)
+  end
+
+  def expect_info(message, data: nil)
+    expect_logged(:info, message, data: data)
+  end
+
+  def expect_debug(message, data: nil)
+    expect_logged(:debug, message, data: data)
+  end
+end
+
+RSpec.configure do |config|
+  config.before do
+    allow(QuietQuality.logger).to receive(:info)
+    allow(QuietQuality.logger).to receive(:warn)
+    allow(QuietQuality.logger).to receive(:debug)
+    allow(QuietQuality.logger).to receive(:increase_level!)
+  end
+
+  config.include LoggerMocking
+end


### PR DESCRIPTION
I'm including a couple of minor actual logging entries here for exhibition purposes (including the one detail I _most often_ wish I had access to - "what is the actual options object right now?"), but for the most part, this slice is about _implementing_ the logger, and not about using it.

We add a Logger class (and a Logging module that provides convenience methods for using it) - it exposes both configuration controls and actual logging methods like `info`, `warn`, and `debug`, which are able to accept an optional data object alongside the message.

The logger writes its logs out in a separate set of colors, and prefixed with a `[ INFO]` style tag (matching the label, of course). Default log-level is 'warn', but for each `-v` passed it will go up one step (currently there's only 'info' and then 'debug', but 'ultra' will probably eventually be warranted).

The logging verbosity can be configured through the cli only, and is completely separate from the `logging` configuration that controls presentation style (`logging: quiet` won't turn off this type of logging for example). We might eventually want to adjust the naming there, but that'll be a breaking change, so I won't worry about it yet.

I definitely recommend reading this by commit, as it is broken down neatly in that direction.

Examples
<img width="432" alt="Screen Shot 2023-06-05 at 1 03 44 PM" src="https://github.com/nevinera/quiet_quality/assets/366133/bfa4774d-c724-43a2-b7bd-3c0c73e37c4e">
<img width="501" alt="Screen Shot 2023-06-05 at 1 04 15 PM" src="https://github.com/nevinera/quiet_quality/assets/366133/299826a3-284f-4ee2-b0b4-844a7f9ee571">
