### PR TITLE
Add more logging for important details

### DIFF
--- a/lib/quiet_quality/executors/pipeline.rb
+++ b/lib/quiet_quality/executors/pipeline.rb
@@ -71,12 +71,12 @@ module QuietQuality
       end
 
       def filtered(messages_object)
-        if filter_messages? && changed_files
-          original_count = messages_object.count
-          messages_object = relevance_filter.filter(messages_object)
-          info("Messages for #{tool_name} filtered from #{original_count} to #{messages_object.count}")
+        return messages_object unless filter_messages? && changed_files
+
+        original_count = messages_object.count
+        relevance_filter.filter(messages_object).tap do |filtered|
+          info("Messages for #{tool_name} filtered from #{original_count} to #{filtered.count}")
         end
-        messages_object
       end
 
       def relocated(messages_object)

--- a/lib/quiet_quality/tools/base_runner.rb
+++ b/lib/quiet_quality/tools/base_runner.rb
@@ -1,6 +1,8 @@
 module QuietQuality
   module Tools
     class BaseRunner
+      include Logging
+
       # In general, we don't want to supply a huge number of arguments to a command-line tool.
       MAX_FILES = 100
 
@@ -36,6 +38,8 @@ module QuietQuality
 
       def performed_outcome
         out, err, stat = Open3.capture3(*command)
+        log_performance(err, stat)
+
         if success_status?(stat)
           Outcome.new(tool: tool_name, output: out, logging: err)
         elsif failure_status?(stat)
@@ -43,6 +47,11 @@ module QuietQuality
         else
           fail(ExecutionError, "Execution of #{tool_name} failed with #{stat.exitstatus}")
         end
+      end
+
+      def log_performance(err, stat)
+        info("Runner #{tool_name} exited with #{stat.exitstatus}")
+        debug("Runner logs from #{tool_name}:", data: err&.split("\n"))
       end
     end
   end

--- a/lib/quiet_quality/tools/relevant_runner.rb
+++ b/lib/quiet_quality/tools/relevant_runner.rb
@@ -48,6 +48,7 @@ module QuietQuality
       end
 
       def skipped_outcome
+        info("Runner #{tool_name} was skipped")
         Outcome.new(tool: tool_name, output: no_files_output)
       end
     end

--- a/spec/quiet_quality/executors/pipeline_spec.rb
+++ b/spec/quiet_quality/executors/pipeline_spec.rb
@@ -115,6 +115,12 @@ RSpec.describe QuietQuality::Executors::Pipeline do
       let(:changed_files) { nil }
       it { is_expected.to be_a(QuietQuality::Messages) }
       it { is_expected.to eq(parsed_messages) }
+
+      it "doesn't log the filtering" do
+        messages
+        expect_not_logged(:info, /filtered from/)
+        expect_not_logged(:info, /positioned/)
+      end
     end
 
     context "with filter_messages disabled" do
@@ -131,6 +137,12 @@ RSpec.describe QuietQuality::Executors::Pipeline do
           end
         end
       end
+
+      it "doesn't log the filtering, but does log repositioning" do
+        messages
+        expect_not_logged(:info, /filtered from/)
+        expect_info("Messages for rspec positioned into the diff for annotation purposes")
+      end
     end
 
     context "with filter_messages enabled" do
@@ -144,6 +156,12 @@ RSpec.describe QuietQuality::Executors::Pipeline do
 
       it "locates those messages properly" do
         expect(messages.first.annotated_line).to eq(5)
+      end
+
+      it "logs the filtering properly" do
+        messages
+        expect_info("Messages for rspec filtered from 6 to 1")
+        expect_info("Messages for rspec positioned into the diff for annotation purposes")
       end
     end
   end

--- a/spec/quiet_quality/tools/runner_examples.rb
+++ b/spec/quiet_quality/tools/runner_examples.rb
@@ -26,6 +26,12 @@ shared_examples "a functional BaseRunner subclass" do |tool_name, options|
       context "with a (successful) exit status of #{success_status}" do
         let(:stat) { mock_status(success_status) }
         it { is_expected.to eq(build_outcome(tool: runner.tool_name, output: out, logging: err, failure: false)) }
+
+        it "logs the performance" do
+          invoke!
+          expect_info("Runner #{runner.tool_name} exited with #{success_status}")
+          expect_debug("Runner logs from #{runner.tool_name}:", data: ["fake stderr"])
+        end
       end
     end
 
@@ -33,6 +39,12 @@ shared_examples "a functional BaseRunner subclass" do |tool_name, options|
       context "with a (failing) exit status of #{failure_status}" do
         let(:stat) { mock_status(failure_status) }
         it { is_expected.to eq(build_outcome(tool: runner.tool_name, output: out, logging: err, failure: true)) }
+
+        it "logs the performance" do
+          invoke!
+          expect_info("Runner #{runner.tool_name} exited with #{failure_status}")
+          expect_debug("Runner logs from #{runner.tool_name}:", data: ["fake stderr"])
+        end
       end
     end
 
@@ -45,6 +57,12 @@ shared_examples "a functional BaseRunner subclass" do |tool_name, options|
             QuietQuality::Tools::ExecutionError,
             /Execution of #{runner.tool_name} failed with #{error_status}/
           )
+        end
+
+        it "logs the performance" do
+          expect { invoke! }.to raise_error(QuietQuality::Error)
+          expect_info("Runner #{runner.tool_name} exited with #{error_status}")
+          expect_debug("Runner logs from #{runner.tool_name}:", data: ["fake stderr"])
         end
       end
     end
@@ -156,6 +174,11 @@ shared_examples "a functional RelevantRunner subclass" do |tool_name, options|
         invoke!
         expect(Open3).not_to have_received(:capture3)
       end
+
+      it "logs the skip" do
+        invoke!
+        expect_info("Runner #{runner.tool_name} was skipped")
+      end
     end
 
     context "when there are no changes to consider" do
@@ -193,6 +216,12 @@ shared_examples "a functional RelevantRunner subclass" do |tool_name, options|
       context "with a (successful) exit status of #{success_status}" do
         let(:stat) { mock_status(success_status) }
         it { is_expected.to eq(build_outcome(tool: runner.tool_name, output: out, logging: err, failure: false)) }
+
+        it "logs the performance" do
+          invoke!
+          expect_info("Runner #{runner.tool_name} exited with #{success_status}")
+          expect_debug("Runner logs from #{runner.tool_name}:", data: ["fake stderr"])
+        end
       end
     end
 
@@ -200,6 +229,12 @@ shared_examples "a functional RelevantRunner subclass" do |tool_name, options|
       context "with a (failing) exit status of #{failure_status}" do
         let(:stat) { mock_status(failure_status) }
         it { is_expected.to eq(build_outcome(tool: runner.tool_name, output: out, logging: err, failure: true)) }
+
+        it "logs the performance" do
+          invoke!
+          expect_info("Runner #{runner.tool_name} exited with #{failure_status}")
+          expect_debug("Runner logs from #{runner.tool_name}:", data: ["fake stderr"])
+        end
       end
     end
 
@@ -212,6 +247,12 @@ shared_examples "a functional RelevantRunner subclass" do |tool_name, options|
             QuietQuality::Tools::ExecutionError,
             /Execution of #{runner.tool_name} failed with #{error_status}/
           )
+        end
+
+        it "logs the performance" do
+          expect { invoke! }.to raise_error(QuietQuality::Error)
+          expect_info("Runner #{runner.tool_name} exited with #{error_status}")
+          expect_debug("Runner logs from #{runner.tool_name}:", data: ["fake stderr"])
         end
       end
     end

--- a/spec/support/logger_mocking.rb
+++ b/spec/support/logger_mocking.rb
@@ -14,6 +14,12 @@ module LoggerMocking
   def expect_debug(message, data: nil)
     expect_logged(:debug, message, data: data)
   end
+
+  def expect_not_logged(level, regex)
+    expect(QuietQuality.logger)
+      .not_to have_received(level)
+      .with(a_string_matching(regex), data: anything)
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Add logging for the rest of the details described in #39. We'll doubtless think of more things to log over time, but this'll be a good start!

* the outcome and the _stderr output_ from each runner
* the filtering and 'relocating' (for annotation purposes) of each message into the diff

Resolves #39 