### PR TITLE
[spike] Adopt `rspec-cover_it` to enforce coverage on a per-spec basis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "rspec-cover_it", path: "../rspec-cover_it"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "rspec-cover_it", path: "../rspec-cover_it"

--- a/lib/quiet_quality/annotators.rb
+++ b/lib/quiet_quality/annotators.rb
@@ -1,10 +1,14 @@
+module QuietQuality
+  module Annotators
+    Unrecognized = Class.new(Error)
+  end
+end
+
 glob = File.expand_path("../annotators/*.rb", __FILE__)
 Dir.glob(glob).sort.each { |f| require(f) }
 
 module QuietQuality
   module Annotators
-    Unrecognized = Class.new(Error)
-
     ANNOTATOR_TYPES = {
       github_stdout: Annotators::GithubStdout
     }.freeze

--- a/quiet_quality.gemspec
+++ b/quiet_quality.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.50"
   spec.add_development_dependency "debug", "~> 1.7"
   spec.add_development_dependency "mdl", "~> 0.12"
+  spec.add_development_dependency "rspec-cover_it", "~> 0.0.1"
 end

--- a/quiet_quality.gemspec
+++ b/quiet_quality.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.50"
   spec.add_development_dependency "debug", "~> 1.7"
   spec.add_development_dependency "mdl", "~> 0.12"
-  spec.add_development_dependency "rspec-cover_it", "~> 0.0.7"
+  spec.add_development_dependency "rspec-cover_it", "~> 0.1.0"
 end

--- a/quiet_quality.gemspec
+++ b/quiet_quality.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.50"
   spec.add_development_dependency "debug", "~> 1.7"
   spec.add_development_dependency "mdl", "~> 0.12"
-  spec.add_development_dependency "rspec-cover_it", "~> 0.0.1"
+  spec.add_development_dependency "rspec-cover_it", "~> 0.0.6"
 end

--- a/quiet_quality.gemspec
+++ b/quiet_quality.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.50"
   spec.add_development_dependency "debug", "~> 1.7"
   spec.add_development_dependency "mdl", "~> 0.12"
-  spec.add_development_dependency "rspec-cover_it", "~> 0.0.6"
+  spec.add_development_dependency "rspec-cover_it", "~> 0.0.7"
 end

--- a/spec/quiet_quality/message_spec.rb
+++ b/spec/quiet_quality/message_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe QuietQuality::Message, cover_it: true do
+RSpec.describe QuietQuality::Message do
   subject(:message) { described_class.new(**attributes) }
 
   let(:attributes) do

--- a/spec/quiet_quality/message_spec.rb
+++ b/spec/quiet_quality/message_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe QuietQuality::Message do
+RSpec.describe QuietQuality::Message, cover_it: true do
   subject(:message) { described_class.new(**attributes) }
 
   let(:attributes) do

--- a/spec/quiet_quality/message_spec.rb
+++ b/spec/quiet_quality/message_spec.rb
@@ -1,4 +1,19 @@
 RSpec.describe QuietQuality::Message do
+  describe ".load" do
+    let(:data) { {path: "foo.rb", body: "some text", tool_name: :rspec, start_line: 52, level: "high"} }
+    subject(:loaded) { described_class.load(data) }
+    it { is_expected.to be_a(described_class) }
+
+    it "has the supplied attributes" do
+      expect(loaded.path).to eq("foo.rb")
+      expect(loaded.body).to eq("some text")
+      expect(loaded.tool_name).to eq(:rspec)
+      expect(loaded.start_line).to eq(52)
+      expect(loaded.level).to eq("high")
+      expect(loaded.rule).to be_nil
+    end
+  end
+
   subject(:message) { described_class.new(**attributes) }
 
   let(:attributes) do

--- a/spec/quiet_quality_spec.rb
+++ b/spec/quiet_quality_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe QuietQuality do
+RSpec.describe QuietQuality, covers_path: "../lib/quiet_quality.rb" do
   describe ".logger" do
     subject(:logger) { described_class.logger }
     it { is_expected.to be_a(QuietQuality::Logger) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "rspec"
 require "rspec/its"
+require "rspec/cover_it"
 require "pry"
 
 if ENV["SIMPLECOV"]
@@ -32,11 +33,13 @@ if ENV["SIMPLECOV"]
   end
 end
 
-require File.expand_path("../../lib/quiet_quality", __FILE__)
-
 gem_root = File.expand_path("../..", __FILE__)
 FIXTURES_DIRECTORY = File.join(gem_root, "spec", "fixtures")
 TEMP_DIRECTORY = File.join(gem_root, "tmp")
+
+RSpec::CoverIt.setup(filter: gem_root)
+
+require File.expand_path("../../lib/quiet_quality", __FILE__)
 
 support_glob = File.join(gem_root, "spec", "support", "**", "*.rb")
 Dir[support_glob].sort.each { |f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,7 @@ gem_root = File.expand_path("../..", __FILE__)
 FIXTURES_DIRECTORY = File.join(gem_root, "spec", "fixtures")
 TEMP_DIRECTORY = File.join(gem_root, "tmp")
 
-RSpec::CoverIt.setup(filter: gem_root)
+RSpec::CoverIt.setup(filter: gem_root, autoenforce: true)
 
 require File.expand_path("../../lib/quiet_quality", __FILE__)
 


### PR DESCRIPTION
That gem isn't actually ready yet (it has no tests, and is written at spike-level right now). So this isn't a real PR yet.