### PR TITLE
Log nil commands correctly (skipped runners)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Release 1.3.1
+
+* Fix a bug around the logging of nil commands when runners are skipped (#104
+  resolves #103)
+
 ## Release 1.3.0
 
 * Support (and enable by default) colorizing the console stderr output from

--- a/lib/quiet_quality/executors/pipeline.rb
+++ b/lib/quiet_quality/executors/pipeline.rb
@@ -54,7 +54,8 @@ module QuietQuality
       end
 
       def log_runner(r)
-        info("Runner #{r.tool_name} command: `#{r.command.join(" ")}`")
+        command_string = r.command ? "`#{r.command.join(" ")}`" : "(skipped)"
+        info("Runner #{r.tool_name} command: #{command_string}")
         debug("Full command for #{r.tool_name}", data: r.command)
       end
 

--- a/lib/quiet_quality/version.rb
+++ b/lib/quiet_quality/version.rb
@@ -1,3 +1,3 @@
 module QuietQuality
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end

--- a/spec/quiet_quality/executors/pipeline_spec.rb
+++ b/spec/quiet_quality/executors/pipeline_spec.rb
@@ -61,6 +61,16 @@ RSpec.describe QuietQuality::Executors::Pipeline do
       end
     end
 
+    context "when the runner is skipping" do
+      before { allow(runner).to receive(:command).and_return(nil) }
+
+      it "logs the empty command" do
+        outcome
+        expect_info("Runner rspec command: (skipped)")
+        expect_debug("Full command for rspec", data: nil)
+      end
+    end
+
     shared_examples "it matches the runner outcome, failure status aside" do
       it "matches the runner outcome, aside from the failure status" do
         expect(outcome.output).to eq(runner_outcome.output)


### PR DESCRIPTION
When a runner skips (because nothing relevant changed), and the result gets _logged_, the logging logic in the Pipeline was calling `.join` on the `nil` command, which doesn't work. Red->green the fix, first add a failing spec exercising it, and then resolve the failure by updating the logging logic in the Pipeline.

Bump the version to 1.3.1

Resolves #103 