### PR TITLE
Allow tool-specific 'excludes' to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Release 1.4.0
+
+* Support specifying `excludes` per-tool, so that certain files won't be passed
+  to those tools on the command-line (#107 resolves #106)
+
 ## Release 1.3.1
 
 * Fix a bug around the logging of nil commands when runners are skipped (#104

--- a/README.md
+++ b/README.md
@@ -156,14 +156,14 @@ And then each tool can have an entry, within which `changed_files` and
 `filter_messages` can be specified - the tool-specific settings override the
 global ones.
 
-The tools have one additional setting that is not available at a global level:
-`file_filter`. This is a string that will be turned into a _ruby regex_, and
-used to limit what file paths are passed to the tool. For example, if you are
-working in a rails engine `engines/foo/`, and you touch one of the rspec tests
-there, you would not want `qq` in the root of the repository to run
-`rspec engines/foo/spec/foo/thing_spec.rb` - that probably won't work, as your
-engine will have its own test setup code and Gemfile. This setting is mostly
-intended to be used like this:
+The tools have two additional settings that are not available at a global level:
+`file_filter` and `excludes`. `file_filter` is a string that will be turned into
+a _ruby regex_, and used to limit what file paths are passed to the tool. For
+example, if you are working in a rails engine `engines/foo/`, and you touch one
+of the rspec tests there, you would not want `qq` in the root of the repository
+to run `rspec engines/foo/spec/foo/thing_spec.rb` - that probably won't work, as
+your engine will have its own test setup code and Gemfile. This setting is
+mostly intended to be used like this:
 
 ```yaml
 rspec:
@@ -171,6 +171,15 @@ rspec:
   filter_messages: false
   file_filter: "^spec/"
 ```
+
+`excludes` are more specific in meaning - this is an _array_ of regexes, and any
+file that matches any of these regexes will _not_ be passed to the tool as an
+explicit command line argument. This is generally because tools like rubocop
+have internal systems for excluding files, but if you pass a filename on the
+cli, those systems are ignored. That means that if you have changes to a
+generated file like `db/schema.rb`, and that file doesn't meet your rubocop (or
+standardrb) rules, you'll get _told_ unless you exclude it at the quiet-quality
+level as well.
 
 ### CLI Options
 

--- a/lib/quiet_quality/config/file_filter.rb
+++ b/lib/quiet_quality/config/file_filter.rb
@@ -1,0 +1,52 @@
+module QuietQuality
+  module Config
+    class FileFilter
+      # * regex is a regex string
+      # * excludes is an array of regex strings OR a single regex string
+      def initialize(regex: nil, excludes: nil)
+        @regex_string = regex
+        @excludes_strings = excludes
+      end
+
+      def regex
+        return nil if @regex_string.nil?
+        @_regex ||= Regexp.new(@regex_string)
+      end
+
+      def excludes
+        return @_excludes if defined?(@_excludes)
+
+        @_excludes =
+          if @excludes_strings.nil?
+            nil
+          elsif @excludes_strings.is_a?(String)
+            [Regexp.new(@excludes_strings)]
+          else
+            @excludes_strings.map { |xs| Regexp.new(xs) }
+          end
+      end
+
+      # The filter _overall_ matches if:
+      # (a) the regex either matches or is not supplied AND
+      # (b) either none of the excludes match or none are supplied
+      def match?(s)
+        regex_match?(s) && !excludes_match?(s)
+      end
+
+      private
+
+      # The regex is an allow-match - if it's not supplied, treat everything as matching.
+      def regex_match?(s)
+        return true if regex.nil?
+        regex.match?(s)
+      end
+
+      # The excludes are a list of deny-matches - if they're not supplied, treat _nothing_
+      # as matching.
+      def excludes_match?(s)
+        return false if excludes.nil? || excludes.empty?
+        excludes.any? { |exclude| exclude.match?(s) }
+      end
+    end
+  end
+end

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -64,7 +64,7 @@ module QuietQuality
         read_tool_option(opts, tool_name, :unfiltered, :filter_messages, as: :reversed_boolean)
         read_tool_option(opts, tool_name, :changed_files, :limit_targets, as: :boolean)
         read_tool_option(opts, tool_name, :all_files, :limit_targets, as: :reversed_boolean)
-        read_tool_option(opts, tool_name, :file_filter, :file_filter, as: :string)
+        read_file_filter(opts, tool_name)
       end
 
       def invalid!(message)
@@ -95,6 +95,15 @@ module QuietQuality
         validate_value("#{tool}.#{name}", parsed_value, as: as)
         coerced_value = coerce_value(parsed_value, as: as)
         opts.set_tool_option(tool, into, coerced_value)
+      end
+
+      def read_file_filter(opts, tool)
+        parsed_regex = data.dig(tool.to_sym, :file_filter)
+        parsed_excludes = data.dig(tool.to_sym, :excludes)
+        if parsed_regex || parsed_excludes
+          filter = Config::FileFilter.new(regex: parsed_regex, excludes: parsed_excludes)
+          opts.set_tool_option(tool, :file_filter, filter)
+        end
       end
 
       def validate_value(name, value, as:, from: nil)

--- a/lib/quiet_quality/config/tool_options.rb
+++ b/lib/quiet_quality/config/tool_options.rb
@@ -8,8 +8,9 @@ module QuietQuality
         @file_filter = file_filter
       end
 
+      attr_accessor :file_filter
       attr_reader :tool_name
-      attr_writer :limit_targets, :filter_messages, :file_filter
+      attr_writer :limit_targets, :filter_messages
 
       def limit_targets?
         @limit_targets
@@ -31,17 +32,13 @@ module QuietQuality
         tool_namespace::Parser
       end
 
-      def file_filter
-        return nil if @file_filter.nil?
-        Regexp.new(@file_filter)
-      end
-
       def to_h
         {
           tool_name: tool_name,
           limit_targets: limit_targets?,
           filter_messages: filter_messages?,
-          file_filter: file_filter&.to_s
+          file_filter: file_filter&.regex&.to_s,
+          excludes: file_filter&.excludes&.map(&:to_s)
         }
       end
     end

--- a/lib/quiet_quality/version.rb
+++ b/lib/quiet_quality/version.rb
@@ -1,3 +1,3 @@
 module QuietQuality
-  VERSION = "1.3.1"
+  VERSION = "1.4.0"
 end

--- a/spec/fixtures/configs/valid.yml
+++ b/spec/fixtures/configs/valid.yml
@@ -10,6 +10,9 @@ rspec:
   filter_messages: false
   changed_files: false
   file_filter: "spec/.*_spec.rb"
+  excludes:
+      - '^db/schema\.rb'
+      - '^db/seeds\.rb'
 standardrb:
   filter_messages: true
 rubocop:

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -334,10 +334,11 @@ RSpec.describe QuietQuality::Config::Builder do
 
         context "with a config file supplied" do
           let(:global_options) { {config_path: "fake.yml"} }
+          let(:file_filter) { QuietQuality::Config::FileFilter.new(regex: ".*", excludes: ["foo", "bar"]) }
 
           context "when the config file sets it" do
-            let(:cfg_tool_options) { {rspec: {file_filter: ".*"}} }
-            it { is_expected.to eq(/.*/) }
+            let(:cfg_tool_options) { {rspec: {file_filter: file_filter}} }
+            it { is_expected.to eq(file_filter) }
           end
 
           context "when the config file does not set it" do

--- a/spec/quiet_quality/config/file_filter_spec.rb
+++ b/spec/quiet_quality/config/file_filter_spec.rb
@@ -1,0 +1,119 @@
+RSpec.describe QuietQuality::Config::FileFilter do
+  subject(:file_filter) { described_class.new(regex: regex_param, excludes: excludes_param) }
+  let(:regex_param) { nil }
+  let(:excludes_param) { nil }
+
+  describe "#regex" do
+    subject(:regex) { file_filter.regex }
+
+    context "when the regex parameter is nil" do
+      let(:regex_param) { nil }
+      it { is_expected.to be_nil }
+    end
+
+    context "when the regex parameter is a simple string" do
+      let(:regex_param) { "foo" }
+      it { is_expected.to eq(/foo/) }
+    end
+
+    context "when the regex parameter is string with regex syntax in it" do
+      let(:regex_param) { "[f-g]+oo.*bar" }
+      it { is_expected.to eq(/[f-g]+oo.*bar/) }
+    end
+  end
+
+  describe "#excludes" do
+    subject(:excludes) { file_filter.excludes }
+
+    context "when the excludes parameter is nil" do
+      let(:excludes_param) { nil }
+      it { is_expected.to be_nil }
+    end
+
+    context "when the excludes parameter is a simple string" do
+      let(:excludes_param) { "foo" }
+      it { is_expected.to contain_exactly(/foo/) }
+    end
+
+    context "when the excludes parameter is a complex regex string" do
+      let(:excludes_param) { "a[b-d]?c*$" }
+      it { is_expected.to contain_exactly(/a[b-d]?c*$/) }
+    end
+
+    context "when the excludes parameter is an array of simple strings" do
+      let(:excludes_param) { ["foo", "bar"] }
+      it { is_expected.to contain_exactly(/foo/, /bar/) }
+    end
+
+    context "when the excludes parameter is an array of complex regex strings" do
+      let(:excludes_param) { ["a[b-d]?c*$", "qq+q?[qQ]*"] }
+      it { is_expected.to contain_exactly(/a[b-d]?c*$/, /qq+q?[qQ]*/) }
+    end
+  end
+
+  describe "#match?" do
+    subject(:match?) { file_filter.match?(path) }
+    let(:path) { "foo/bar/baz.zam" }
+
+    context "when neither regex nor excludes are supplied" do
+      let(:regex_param) { nil }
+      let(:excludes_param) { nil }
+      it { is_expected.to be_truthy }
+    end
+
+    context "when regex is supplied without excludes" do
+      let(:regex_param) { "foo" }
+      let(:excludes_param) { nil }
+
+      context "when the regex matches the path" do
+        let(:path) { "biz/fooba/bam" }
+        it { is_expected.to be_truthy }
+      end
+
+      context "when the regex does not match the path" do
+        let(:path) { "something/else" }
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    context "when excludes are supplied without regex" do
+      let(:regex_param) { nil }
+      let(:excludes_param) { ["ab+d", "ab+c"] }
+
+      context "when the path matches none of the excludes" do
+        let(:path) { "none/of/those" }
+        it { is_expected.to be_truthy }
+      end
+
+      context "when the path matches one of the excludes" do
+        let(:path) { "path/abbbbd/file" }
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    context "when both regex and excludes are supplied" do
+      let(:regex_param) { "foo" }
+      let(:excludes_param) { ["ab+d", "ab+c"] }
+
+      context "when the path matches neither the regex nor the excludes" do
+        let(:path) { "other/path" }
+        it { is_expected.to be_falsey }
+      end
+
+      context "when the path matches the regex and not the excludes" do
+        let(:path) { "path/to/fooba" }
+        it { is_expected.to be_truthy }
+      end
+
+      context "when the path matches the excludes and the regex" do
+        let(:path) { "path/to/fooba/abbbc.zip" }
+        it { is_expected.to be_falsey }
+      end
+
+      context "when the path matches the excludes and not the regex" do
+        let(:path) { "path/to/abbc.txt" }
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/config/options_spec.rb
+++ b/spec/quiet_quality/config/options_spec.rb
@@ -91,12 +91,14 @@ RSpec.describe QuietQuality::Config::Options do
           rspec: {
             tool_name: :rspec,
             file_filter: nil,
+            excludes: nil,
             filter_messages: true,
             limit_targets: true
           },
           standardrb: {
             tool_name: :standardrb,
             file_filter: nil,
+            excludes: nil,
             filter_messages: false,
             limit_targets: true
           }

--- a/spec/quiet_quality/config/tool_options_spec.rb
+++ b/spec/quiet_quality/config/tool_options_spec.rb
@@ -27,17 +27,6 @@ RSpec.describe QuietQuality::Config::ToolOptions do
     end
   end
 
-  describe "#file_filter" do
-    subject(:file_filter) { tool_options.file_filter }
-    it { is_expected.to be_nil }
-
-    context "when set with a string" do
-      before { tool_options.file_filter = ".*" }
-      it { is_expected.to be_a(Regexp) }
-      it { is_expected.to eq(/.*/) }
-    end
-  end
-
   describe "constants for tools" do
     shared_examples "exposes the expected constants for" do |tool_name, expected_namespace|
       context "for #{tool_name}" do
@@ -60,14 +49,16 @@ RSpec.describe QuietQuality::Config::ToolOptions do
     subject(:to_h) { tool_options.to_h }
 
     context "with all attributes supplied" do
-      let(:tool_options) { described_class.new(:rspec, limit_targets: true, filter_messages: false, file_filter: /^foo.*$/i) }
+      let(:file_filter) { QuietQuality::Config::FileFilter.new(regex: /^foo.*$/i, excludes: [/foo/, /bar/]) }
+      let(:tool_options) { described_class.new(:rspec, limit_targets: true, filter_messages: false, file_filter: file_filter) }
 
       it "produces the expected hash" do
         expect(to_h).to eq({
           tool_name: :rspec,
           limit_targets: true,
           filter_messages: false,
-          file_filter: "(?i-mx:^foo.*$)"
+          file_filter: "(?i-mx:^foo.*$)",
+          excludes: ["(?-mix:foo)", "(?-mix:bar)"]
         })
       end
     end
@@ -80,7 +71,8 @@ RSpec.describe QuietQuality::Config::ToolOptions do
           tool_name: :standardrb,
           limit_targets: true,
           filter_messages: false,
-          file_filter: nil
+          file_filter: nil,
+          excludes: nil
         })
       end
     end


### PR DESCRIPTION
The core issue here is that, if you are using `changed_files` to limit the targets of certain tools (mainly rubocop/standardrb), it will do so by listing out the files to target for the cli tool. But _rubocop_ thinks that if you specify a path on the command line, you clearly _mean it_, and therefore that overrides the built-in exclude/ignore system it has in place; as a result, if you are working in a branch that has changes in schema.rb (for example), you will start getting rubocop warnings about that autogenerated file _even though it is rubocop-ignored already_. Quite annoying, clearly.

While this was _technically_ possible already via excessively complex regexes in the 'file_filter' parameter, that would have been really terrible to work with. So instead, we add an extra (config-file only) option called 'excludes', which takes an _array_ of regex strings (strings that will be passed to `Regexp.new`) - if a file path matches any of the exclude strings for a tool, the runner will _not_ list it explicitly.

Under the hood, this is done by replacing the `file_filter` ToolOption value, which _was_ a Regexp, with a new QuietQuality::Config::FileFilter object that has both the original regex AND the new exclude regexes, and does both sets of comparisons. A thing "matches" the filter if the filter is willing to let it proceed, which means the actual invocation by the Runners to construct their commands doesn't change at all.

Resolves #106 