### PR TITLE
Add a way to 'exec' a single tool

### DIFF
--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -103,7 +103,7 @@ module QuietQuality
 
         parser.on("-X", "--exec TOOL", "Exec one tool instead of managing several") do |tool_name|
           validate_value_from("tool", tool_name, Tools::AVAILABLE)
-          set_global_option(:exec, tool_name.to_sym)
+          set_global_option(:exec_tool, tool_name.to_sym)
         end
       end
 

--- a/lib/quiet_quality/cli/arg_parser.rb
+++ b/lib/quiet_quality/cli/arg_parser.rb
@@ -100,6 +100,11 @@ module QuietQuality
           validate_value_from("executor", name, Executors::AVAILABLE)
           set_global_option(:executor, name.to_sym)
         end
+
+        parser.on("-X", "--exec TOOL", "Exec one tool instead of managing several") do |tool_name|
+          validate_value_from("tool", tool_name, Tools::AVAILABLE)
+          set_global_option(:exec, tool_name.to_sym)
+        end
       end
 
       def setup_annotation_options(parser)

--- a/lib/quiet_quality/cli/entrypoint.rb
+++ b/lib/quiet_quality/cli/entrypoint.rb
@@ -18,7 +18,7 @@ module QuietQuality
           log_no_tools_text
         else
           log_options
-          executed
+          execute!
           log_results
           annotate_messages
         end
@@ -112,6 +112,26 @@ module QuietQuality
         return @_executed if defined?(@_executed)
         executor.execute!
         @_executed = executor
+      end
+
+      def exec_tool_options
+        @_exec_tool_options ||= options.tools
+          .detect { |topts| topts.tool_name == options.exec_tool.to_sym }
+      end
+
+      def execcer
+        @_execcer ||= QuietQuality::Executors::Execcer.new(
+          tool_options: exec_tool_options,
+          changed_files: changed_files
+        )
+      end
+
+      def execute!
+        if options.exec_tool
+          execcer.exec!
+        else
+          executed
+        end
       end
 
       def annotate_messages

--- a/lib/quiet_quality/config/builder.rb
+++ b/lib/quiet_quality/config/builder.rb
@@ -22,7 +22,7 @@ module QuietQuality
         Options.new.tap { |opts| opts.tools = tools }
       end
 
-      def tool_names
+      def specified_tool_names
         if cli.tools.any?
           cli.tools
         elsif config_file&.tools&.any?
@@ -30,6 +30,14 @@ module QuietQuality
         else
           []
         end
+      end
+
+      def exec_tool_name
+        cli.global_option(:exec_tool)
+      end
+
+      def tool_names
+        (specified_tool_names + [exec_tool_name]).compact.uniq
       end
 
       def config_finder
@@ -84,6 +92,7 @@ module QuietQuality
         def update_globals
           update_annotator
           update_executor
+          update_exec_tool
           update_comparison_branch
           update_logging
         end
@@ -98,6 +107,10 @@ module QuietQuality
           executor_name = apply.global_option(:executor)
           return if executor_name.nil?
           options.executor = Executors::AVAILABLE.fetch(executor_name)
+        end
+
+        def update_exec_tool
+          set_unless_nil(options, :exec_tool, apply.global_option(:exec_tool))
         end
 
         def update_comparison_branch

--- a/lib/quiet_quality/config/options.rb
+++ b/lib/quiet_quality/config/options.rb
@@ -7,12 +7,13 @@ module QuietQuality
         @annotator = nil
         @executor = Executors::ConcurrentExecutor
         @tools = nil
+        @exec_tool = nil
         @comparison_branch = nil
         @colorize = true
         @logging = :normal
       end
 
-      attr_accessor :tools, :comparison_branch, :annotator, :executor
+      attr_accessor :tools, :comparison_branch, :annotator, :executor, :exec_tool
       attr_reader :logging
       attr_writer :colorize
 
@@ -37,6 +38,7 @@ module QuietQuality
         {
           annotator: annotator,
           executor: executor.name,
+          exec_tool: exec_tool,
           comparison_branch: comparison_branch,
           colorize: colorize?,
           logging: logging,

--- a/lib/quiet_quality/config/parsed_options.rb
+++ b/lib/quiet_quality/config/parsed_options.rb
@@ -8,7 +8,7 @@ module QuietQuality
         :config_path,
         :annotator,
         :executor,
-        :exec,
+        :exec_tool,
         :comparison_branch,
         :colorize,
         :logging,

--- a/lib/quiet_quality/config/parsed_options.rb
+++ b/lib/quiet_quality/config/parsed_options.rb
@@ -8,6 +8,7 @@ module QuietQuality
         :config_path,
         :annotator,
         :executor,
+        :exec,
         :comparison_branch,
         :colorize,
         :logging,

--- a/lib/quiet_quality/executors/execcer.rb
+++ b/lib/quiet_quality/executors/execcer.rb
@@ -12,9 +12,11 @@ module QuietQuality
         if runner.exec_command
           Kernel.exec(*runner.exec_command)
         else
-          info "This runner does not believe it needs to execute at all."
-          info "This typically means that it was told to target changed-files, but no relevant"
-          info "files were changed."
+          info <<~LOG_MESSAGE
+            This runner does not believe it needs to execute at all.
+            This typically means that it was told to target changed-files, but no relevant
+            files were changed.
+          LOG_MESSAGE
           Kernel.exit(0)
         end
       end

--- a/lib/quiet_quality/tools/base_runner.rb
+++ b/lib/quiet_quality/tools/base_runner.rb
@@ -23,6 +23,10 @@ module QuietQuality
         fail(NoMethodError, "BaseRunner subclass must implement `command`")
       end
 
+      def exec_command
+        fail(NoMethodError, "BaseRunner subclass must implement `exec_command`")
+      end
+
       def success_status?(stat)
         stat.success?
       end

--- a/lib/quiet_quality/tools/brakeman/runner.rb
+++ b/lib/quiet_quality/tools/brakeman/runner.rb
@@ -10,6 +10,10 @@ module QuietQuality
           ["brakeman", "-f", "json"]
         end
 
+        def exec_command
+          ["brakeman"]
+        end
+
         # These are specified in constants at the top of brakeman.rb:
         #   https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman.rb#L6-L25
         def failure_status?(stat)

--- a/lib/quiet_quality/tools/haml_lint/runner.rb
+++ b/lib/quiet_quality/tools/haml_lint/runner.rb
@@ -14,6 +14,10 @@ module QuietQuality
           ["haml-lint", "--reporter", "json"]
         end
 
+        def base_exec_command
+          ["haml-lint"]
+        end
+
         def relevant_path?(path)
           path.end_with?(".haml")
         end

--- a/lib/quiet_quality/tools/markdown_lint/runner.rb
+++ b/lib/quiet_quality/tools/markdown_lint/runner.rb
@@ -10,13 +10,19 @@ module QuietQuality
           "[]"
         end
 
-        def command
+        def command(json: true)
           return nil if skip_execution?
+          base_command = ["mdl"]
+          base_command << "--json" if json
           if target_files.any?
-            ["mdl", "--json"] + target_files.sort
+            base_command + target_files.sort
           else
-            ["mdl", "--json", "."]
+            base_command + ["."]
           end
+        end
+
+        def exec_command
+          command(json: false)
         end
 
         def relevant_path?(path)

--- a/lib/quiet_quality/tools/relevant_runner.rb
+++ b/lib/quiet_quality/tools/relevant_runner.rb
@@ -16,12 +16,21 @@ module QuietQuality
         base_command + target_files.sort
       end
 
+      def exec_command
+        return nil if skip_execution?
+        base_exec_command + target_files.sort
+      end
+
       def relevant_path?(path)
         fail(NoMethodError, "RelevantRunner subclass must implement `relevant_path?`")
       end
 
       def base_command
         fail(NoMethodError, "RelevantRunner subclass must implement either `command` or `base_command`")
+      end
+
+      def base_exec_command
+        fail(NoMethodError, "RelevantRunner subclass must implement either `exec_command` or `base_exec_command`")
       end
 
       def no_files_output

--- a/lib/quiet_quality/tools/rspec/runner.rb
+++ b/lib/quiet_quality/tools/rspec/runner.rb
@@ -14,6 +14,10 @@ module QuietQuality
           ["rspec", "-f", "json"]
         end
 
+        def base_exec_command
+          ["rspec"]
+        end
+
         def relevant_path?(path)
           path.end_with?("_spec.rb")
         end

--- a/lib/quiet_quality/tools/rubocop/runner.rb
+++ b/lib/quiet_quality/tools/rubocop/runner.rb
@@ -14,6 +14,10 @@ module QuietQuality
           ["rubocop", "-f", "json"]
         end
 
+        def base_exec_command
+          ["rubocop"]
+        end
+
         def relevant_path?(path)
           path.end_with?(".rb")
         end

--- a/lib/quiet_quality/tools/standardrb/runner.rb
+++ b/lib/quiet_quality/tools/standardrb/runner.rb
@@ -14,6 +14,10 @@ module QuietQuality
           ["standardrb", "-f", "json"]
         end
 
+        def base_exec_command
+          ["standardrb"]
+        end
+
         def relevant_path?(path)
           path.end_with?(".rb")
         end

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -126,15 +126,15 @@ RSpec.describe QuietQuality::Cli::ArgParser do
     end
 
     describe "executor options" do
-      expect_options("(none)", [], global: {executor: nil, exec: nil})
+      expect_options("(none)", [], global: {executor: nil, exec_tool: nil})
       expect_options("--executor concurrent", ["--executor", "concurrent"], global: {executor: :concurrent})
       expect_options("--executor serial", ["--executor", "serial"], global: {executor: :serial})
       expect_options("-Econcurrent", ["-Econcurrent"], global: {executor: :concurrent})
       expect_options("-Eserial", ["-Eserial"], global: {executor: :serial})
       expect_usage_error("--executor fooba", ["--executor", "fooba"], /Unrecognized executor/)
       expect_usage_error("-Efooba", ["-Efooba"], /Unrecognized executor/)
-      expect_options("--exec rspec", ["--exec", "rspec"], global: {exec: :rspec})
-      expect_options("-Xrspec", ["-Xrspec"], global: {exec: :rspec})
+      expect_options("--exec rspec", ["--exec", "rspec"], global: {exec_tool: :rspec})
+      expect_options("-Xrspec", ["-Xrspec"], global: {exec_tool: :rspec})
     end
 
     describe "annotation options" do

--- a/spec/quiet_quality/cli/arg_parser_spec.rb
+++ b/spec/quiet_quality/cli/arg_parser_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe QuietQuality::Cli::ArgParser do
             -C, --config PATH                Load a config file from this path
             -N, --no-config                  Do not load a config file, even if present
             -E, --executor EXECUTOR          Which executor to use
+            -X, --exec TOOL                  Exec one tool instead of managing several
             -A, --annotate ANNOTATOR         Annotate with this annotator
             -G, --annotate-github-stdout     Annotate with GitHub Workflow commands
             -a, --all-files [tool]           Use the tool(s) on all files
@@ -125,13 +126,15 @@ RSpec.describe QuietQuality::Cli::ArgParser do
     end
 
     describe "executor options" do
-      expect_options("(none)", [], global: {executor: nil})
+      expect_options("(none)", [], global: {executor: nil, exec: nil})
       expect_options("--executor concurrent", ["--executor", "concurrent"], global: {executor: :concurrent})
       expect_options("--executor serial", ["--executor", "serial"], global: {executor: :serial})
       expect_options("-Econcurrent", ["-Econcurrent"], global: {executor: :concurrent})
       expect_options("-Eserial", ["-Eserial"], global: {executor: :serial})
       expect_usage_error("--executor fooba", ["--executor", "fooba"], /Unrecognized executor/)
       expect_usage_error("-Efooba", ["-Efooba"], /Unrecognized executor/)
+      expect_options("--exec rspec", ["--exec", "rspec"], global: {exec: :rspec})
+      expect_options("-Xrspec", ["-Xrspec"], global: {exec: :rspec})
     end
 
     describe "annotation options" do

--- a/spec/quiet_quality/cli/entrypoint_spec.rb
+++ b/spec/quiet_quality/cli/entrypoint_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
       it { is_expected.to eq(entrypoint) }
       it { is_expected.to be_successful }
 
-      it "presents the outcomes properly" do
+      it "presents the outcomes properly", aggregate_failures: true do
         execute
         expect(presenter_class).to have_received(:new).with(
           stream: error_stream,
@@ -91,7 +91,7 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
       it { is_expected.to eq(entrypoint) }
       it { is_expected.not_to be_successful }
 
-      it "presents the outcomes properly" do
+      it "presents the outcomes properly", aggregate_failures: true do
         execute
         expect(presenter_class).to have_received(:new).with(
           stream: error_stream,
@@ -106,7 +106,7 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
         let(:argv) { ["--annotate", "github_stdout"] }
         let(:options) { build_options(annotator: :github_stdout, rubocop: {}, rspec: {}) }
 
-        it "writes the proper annotations to stdout" do
+        it "writes the proper annotations to stdout", aggregate_failures: true do
           execute
           expect(output_stream).to have_received(:puts).with("::warning file=foo.rb,line=1,title=just_delete_everything::Msg1")
           expect(output_stream).to have_received(:puts).with("::warning file=bar.rb,line=2,title=complexity_checks_that_make_things_worse Title::Msg2")
@@ -189,7 +189,7 @@ RSpec.describe QuietQuality::Cli::Entrypoint do
         nil
       end
 
-      it "invokes the execcer correctly" do
+      it "invokes the execcer correctly", aggregate_failures: true do
         rescued_execute
 
         expect(QuietQuality::Executors::Execcer).to have_received(:new).with(

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -80,6 +80,20 @@ RSpec.describe QuietQuality::Config::Builder do
       end
     end
 
+    describe "#exec_tool" do
+      subject(:exec_tool) { options.exec_tool }
+
+      context "when global_options[:exec_tool] is unset" do
+        let(:global_options) { {} }
+        it { is_expected.to be_nil }
+      end
+
+      context "when global_options[:exec_tool] is :rspec" do
+        let(:global_options) { {exec_tool: :rspec} }
+        it { is_expected.to eq(:rspec) }
+      end
+    end
+
     describe "#comparison_branch" do
       subject(:comparison_branch) { options.comparison_branch }
 
@@ -212,6 +226,36 @@ RSpec.describe QuietQuality::Config::Builder do
 
           it "uses the cli values" do
             expect(tools.map(&:tool_name)).to contain_exactly(:rspec, :standardrb)
+          end
+        end
+      end
+
+      context "when exec_tool is supplied" do
+        let(:global_options) { {exec_tool: :rspec} }
+
+        context "and no tools are specified on the cli" do
+          let(:tool_names) { [] }
+
+          it "treats the exec_tool as a listed tool" do
+            expect(tools.map(&:tool_name)).to contain_exactly(:rspec)
+          end
+        end
+
+        context "and some tools are specified on the cli" do
+          context "but it is not one of them" do
+            let(:tool_names) { [:standardrb] }
+
+            it "adds the exec_tool to the listed tools" do
+              expect(tools.map(&:tool_name)).to contain_exactly(:rspec, :standardrb)
+            end
+          end
+
+          context "and it is one of them" do
+            let(:tool_names) { [:rspec, :standardrb] }
+
+            it "does not change the listed tools" do
+              expect(tools.map(&:tool_name)).to contain_exactly(:rspec, :standardrb)
+            end
           end
         end
       end

--- a/spec/quiet_quality/config/options_spec.rb
+++ b/spec/quiet_quality/config/options_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe QuietQuality::Config::Options do
   it "has the expected default values" do
     expect(options.annotator).to be_nil
     expect(options.executor).to eq(QuietQuality::Executors::ConcurrentExecutor)
+    expect(options.exec_tool).to be_nil
     expect(options.tools).to be_nil
     expect(options.comparison_branch).to be_nil
     expect(options.colorize?).to be(true)
@@ -13,6 +14,7 @@ RSpec.describe QuietQuality::Config::Options do
   it { is_expected.to respond_to(:tools=) }
   it { is_expected.to respond_to(:annotator=) }
   it { is_expected.to respond_to(:executor=) }
+  it { is_expected.to respond_to(:exec_tool=) }
   it { is_expected.to respond_to(:comparison_branch=) }
   it { is_expected.to respond_to(:colorize=) }
 
@@ -86,6 +88,7 @@ RSpec.describe QuietQuality::Config::Options do
         colorize: true,
         comparison_branch: nil,
         executor: "QuietQuality::Executors::ConcurrentExecutor",
+        exec_tool: nil,
         logging: :normal,
         tools: {
           rspec: {

--- a/spec/quiet_quality/executors/execcer_spec.rb
+++ b/spec/quiet_quality/executors/execcer_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe QuietQuality::Executors::Execcer do
           .with(changed_files: changed_files, file_filter: file_filter)
       end
 
-      it "logs correctly" do
+      it "logs correctly", aggregate_failures: true do
         exec!
         expect_info("Runner rspec exec_command: `foo bar`")
         expect_debug("Full exec_command for rspec", data: ["foo", "bar"])
       end
 
-      it "calls Kernel.exec correctly" do
+      it "calls Kernel.exec correctly", aggregate_failures: true do
         exec!
         expect(Kernel).to have_received(:exec).with("foo", "bar")
         expect(Kernel).not_to have_received(:exit)
@@ -55,13 +55,13 @@ RSpec.describe QuietQuality::Executors::Execcer do
           .with(changed_files: nil, file_filter: file_filter)
       end
 
-      it "logs correctly" do
+      it "logs correctly", aggregate_failures: true do
         exec!
         expect_info("Runner rspec exec_command: `foo bar`")
         expect_debug("Full exec_command for rspec", data: ["foo", "bar"])
       end
 
-      it "calls Kernel.exec correctly" do
+      it "calls Kernel.exec correctly", aggregate_failures: true do
         exec!
         expect(Kernel).to have_received(:exec).with("foo", "bar")
         expect(Kernel).not_to have_received(:exit)
@@ -79,13 +79,13 @@ RSpec.describe QuietQuality::Executors::Execcer do
           .with(changed_files: changed_files, file_filter: file_filter)
       end
 
-      it "logs correctly" do
+      it "logs correctly", aggregate_failures: true do
         exec!
         expect_info("Runner rspec exec_command: (skipped)")
         expect_debug("Full exec_command for rspec", data: nil)
       end
 
-      it "calls Kernel.exit instead of Kernel.exec" do
+      it "calls Kernel.exit instead of Kernel.exec", aggregate_failures: true do
         exec!
         expect_info <<~LOG_MESSAGE
           This runner does not believe it needs to execute at all.

--- a/spec/quiet_quality/executors/execcer_spec.rb
+++ b/spec/quiet_quality/executors/execcer_spec.rb
@@ -1,0 +1,98 @@
+RSpec.describe QuietQuality::Executors::Execcer do
+  let(:limit_targets?) { true }
+  let(:file_filter) { ".*" }
+  let(:tool_name) { :rspec }
+  let(:tool_opts) { tool_options(tool_name, limit_targets: limit_targets?, file_filter: file_filter) }
+
+  let(:foo_file) { QuietQuality::ChangedFile.new(path: "path/foo.rb", lines: [1, 2, 3, 5, 10]) }
+  let(:bar_file) { QuietQuality::ChangedFile.new(path: "path/bar.rb", lines: [5, 6, 7, 14, 15]) }
+  let(:bug_file) { QuietQuality::ChangedFile.new(path: "path/bug.rb", lines: :all) }
+  let(:changed_files) { QuietQuality::ChangedFiles.new([foo_file, bar_file, bug_file]) }
+
+  let(:runner_class) { QuietQuality::Tools::Rspec::Runner }
+  let(:exec_command) { ["foo", "bar"] }
+  let(:runner) { instance_double(runner_class, tool_name: :rspec, exec_command: exec_command) }
+  before { allow(runner_class).to receive(:new).and_return(runner) }
+
+  before { allow(Kernel).to receive(:exec) }
+  before { allow(Kernel).to receive(:exit) }
+
+  subject(:execcer) { described_class.new(tool_options: tool_opts, changed_files: changed_files) }
+
+  describe "#exec!" do
+    subject(:exec!) { execcer.exec! }
+
+    context "when the targets are to be limited" do
+      let(:limit_targets?) { true }
+
+      it "sets up the runner correctly" do
+        exec!
+        expect(runner_class)
+          .to have_received(:new)
+          .with(changed_files: changed_files, file_filter: file_filter)
+      end
+
+      it "logs correctly" do
+        exec!
+        expect_info("Runner rspec exec_command: `foo bar`")
+        expect_debug("Full exec_command for rspec", data: ["foo", "bar"])
+      end
+
+      it "calls Kernel.exec correctly" do
+        exec!
+        expect(Kernel).to have_received(:exec).with("foo", "bar")
+        expect(Kernel).not_to have_received(:exit)
+      end
+    end
+
+    context "when the targets are not to be limited" do
+      let(:limit_targets?) { false }
+
+      it "sets up the runner correctly" do
+        exec!
+        expect(runner_class)
+          .to have_received(:new)
+          .with(changed_files: nil, file_filter: file_filter)
+      end
+
+      it "logs correctly" do
+        exec!
+        expect_info("Runner rspec exec_command: `foo bar`")
+        expect_debug("Full exec_command for rspec", data: ["foo", "bar"])
+      end
+
+      it "calls Kernel.exec correctly" do
+        exec!
+        expect(Kernel).to have_received(:exec).with("foo", "bar")
+        expect(Kernel).not_to have_received(:exit)
+      end
+    end
+
+    context "when the runner is skipping" do
+      let(:limit_targets) { true }
+      let(:exec_command) { nil }
+
+      it "sets up the runner correctly" do
+        exec!
+        expect(runner_class)
+          .to have_received(:new)
+          .with(changed_files: changed_files, file_filter: file_filter)
+      end
+
+      it "logs correctly" do
+        exec!
+        expect_info("Runner rspec exec_command: (skipped)")
+        expect_debug("Full exec_command for rspec", data: nil)
+      end
+
+      it "calls Kernel.exit instead of Kernel.exec" do
+        exec!
+        expect_info "This runner does not believe it needs to execute at all."
+        expect_info "This typically means that it was told to target changed-files, but no relevant"
+        expect_info "files were changed."
+        expect(Kernel).to have_received(:exit).with(0)
+        expect(Kernel).not_to have_received(:exec)
+      end
+    end
+  end
+end

--- a/spec/quiet_quality/executors/execcer_spec.rb
+++ b/spec/quiet_quality/executors/execcer_spec.rb
@@ -87,9 +87,11 @@ RSpec.describe QuietQuality::Executors::Execcer do
 
       it "calls Kernel.exit instead of Kernel.exec" do
         exec!
-        expect_info "This runner does not believe it needs to execute at all."
-        expect_info "This typically means that it was told to target changed-files, but no relevant"
-        expect_info "files were changed."
+        expect_info <<~LOG_MESSAGE
+          This runner does not believe it needs to execute at all.
+          This typically means that it was told to target changed-files, but no relevant
+          files were changed.
+        LOG_MESSAGE
         expect(Kernel).to have_received(:exit).with(0)
         expect(Kernel).not_to have_received(:exec)
       end

--- a/spec/quiet_quality/tools/base_runner_spec.rb
+++ b/spec/quiet_quality/tools/base_runner_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe QuietQuality::Tools::BaseRunner do
         expect { command }.to raise_error(NoMethodError, /must implement.*command/i)
       end
     end
+
+    describe "#exec_command" do
+      subject(:exec_command) { runner.exec_command }
+
+      it "raises a NoMethodError" do
+        expect { exec_command }.to raise_error(NoMethodError, /must implement.*exec_command/i)
+      end
+    end
   end
 
   context "with a properly implemented subclass" do

--- a/spec/quiet_quality/tools/brakeman/runner_spec.rb
+++ b/spec/quiet_quality/tools/brakeman/runner_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe QuietQuality::Tools::Brakeman::Runner do
     it { is_expected.to eq(["brakeman", "-f", "json"]) }
   end
 
+  describe "#exec_command" do
+    subject(:exec_command) { runner.exec_command }
+    it { is_expected.to eq(["brakeman"]) }
+  end
+
   it_behaves_like "a functional BaseRunner subclass", :brakeman, failure: (3..8) do
     it "calls brakeman correctly" do
       runner.invoke!

--- a/spec/quiet_quality/tools/haml_lint/runner_spec.rb
+++ b/spec/quiet_quality/tools/haml_lint/runner_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe QuietQuality::Tools::HamlLint::Runner do
     irrelevant: "foo.html.erb",
     filter: /foo/,
     base_command: ["haml-lint", "--reporter", "json"],
+    base_exec_command: ["haml-lint"],
     failure: [65],
     error: [1, 2, 3, 99]
   }
@@ -31,6 +32,11 @@ RSpec.describe QuietQuality::Tools::HamlLint::Runner do
   describe "#base_command" do
     subject(:base_command) { runner.base_command }
     it { is_expected.to eq(["haml-lint", "--reporter", "json"]) }
+  end
+
+  describe "#base_exec_command" do
+    subject(:base_exec_command) { runner.base_exec_command }
+    it { is_expected.to eq(["haml-lint"]) }
   end
 
   describe "#relevant_path?" do

--- a/spec/quiet_quality/tools/markdown_lint/runner_spec.rb
+++ b/spec/quiet_quality/tools/markdown_lint/runner_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe QuietQuality::Tools::MarkdownLint::Runner do
     relevant: "foo.md",
     irrelevant: "foo.txt",
     filter: /foo/,
-    base_command: :skip
+    base_command: :skip,
+    base_exec_command: :skip
   }
 
   describe "#tool_name" do
@@ -74,6 +75,39 @@ RSpec.describe QuietQuality::Tools::MarkdownLint::Runner do
         let(:file_filter) { /foo|bar/ }
         let(:changed_files) { fully_changed_files("foo.md", "bar.md", "baz.md", "foo.txt") }
         it { is_expected.to eq(["mdl", "--json", "bar.md", "foo.md"]) }
+      end
+    end
+  end
+
+  describe "#exec_command" do
+    subject(:exec_command) { runner.exec_command }
+
+    context "when there are no changed to consider" do
+      let(:changed_files) { nil }
+      it { is_expected.to eq(["mdl", "."]) }
+    end
+
+    context "when there are changed to consider" do
+      context "but they are empty" do
+        let(:changed_files) { empty_changed_files }
+        it { is_expected.to be_nil }
+      end
+
+      context "but they contain no markdown files" do
+        let(:changed_files) { fully_changed_files("foo.txt") }
+        it { is_expected.to be_nil }
+      end
+
+      context "but they contain no files matching the file_filter" do
+        let(:file_filter) { /baz/ }
+        let(:changed_files) { fully_changed_files("foo.md", "bar.md") }
+        it { is_expected.to be_nil }
+      end
+
+      context "and they contain some files that are relevant" do
+        let(:file_filter) { /foo|bar/ }
+        let(:changed_files) { fully_changed_files("foo.md", "bar.md", "baz.md", "foo.txt") }
+        it { is_expected.to eq(["mdl", "bar.md", "foo.md"]) }
       end
     end
   end

--- a/spec/quiet_quality/tools/relevant_runner_spec.rb
+++ b/spec/quiet_quality/tools/relevant_runner_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe QuietQuality::Tools::RelevantRunner do
       end
     end
 
+    describe "#exec_command" do
+      subject(:exec_command) { runner.exec_command }
+
+      it "raises a NoMethodError" do
+        expect { exec_command }.to raise_error(NoMethodError)
+      end
+    end
+
     describe "#relevant_path?" do
       let(:path) { "fake/path" }
       subject(:relevant_path?) { runner.relevant_path?(path) }
@@ -40,6 +48,15 @@ RSpec.describe QuietQuality::Tools::RelevantRunner do
       it "raises a NoMethodError" do
         expect { base_command }
           .to raise_error(NoMethodError, /RelevantRunner subclass must.*command.*base_command/)
+      end
+    end
+
+    describe "#base_exec_command" do
+      subject(:base_exec_command) { runner.base_exec_command }
+
+      it "raises a NoMethodError" do
+        expect { base_exec_command }
+          .to raise_error(NoMethodError, /RelevantRunner subclass must.*exec_command.*base_exec_command/)
       end
     end
 
@@ -66,6 +83,10 @@ RSpec.describe QuietQuality::Tools::RelevantRunner do
 
         def base_command
           ["fake", "command"]
+        end
+
+        def base_exec_command
+          ["fake", "exec"]
         end
 
         def no_files_output
@@ -154,7 +175,8 @@ RSpec.describe QuietQuality::Tools::RelevantRunner do
       relevant: "foo.rb",
       irrelevant: "bar.rb",
       filter: /\.rb/,
-      base_command: ["fake", "command"]
+      base_command: ["fake", "command"],
+      base_exec_command: ["fake", "exec"]
     }
   end
 end

--- a/spec/quiet_quality/tools/rspec/runner_spec.rb
+++ b/spec/quiet_quality/tools/rspec/runner_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
     relevant: "foo_spec.rb",
     irrelevant: "bar.ts",
     filter: /\.rb/,
-    base_command: ["rspec", "-f", "json"]
+    base_command: ["rspec", "-f", "json"],
+    base_exec_command: ["rspec"]
   }
 
   describe "#tool_name" do
@@ -30,6 +31,11 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
   describe "#base_command" do
     subject(:base_command) { runner.base_command }
     it { is_expected.to eq(["rspec", "-f", "json"]) }
+  end
+
+  describe "#base_exec_command" do
+    subject(:base_exec_command) { runner.base_exec_command }
+    it { is_expected.to eq(["rspec"]) }
   end
 
   describe "#relevant_path?" do

--- a/spec/quiet_quality/tools/rubocop/runner_spec.rb
+++ b/spec/quiet_quality/tools/rubocop/runner_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe QuietQuality::Tools::Rubocop::Runner do
     relevant: "foo.rb",
     irrelevant: "foo.ts",
     filter: /foo/,
-    base_command: ["rubocop", "-f", "json"]
+    base_command: ["rubocop", "-f", "json"],
+    base_exec_command: ["rubocop"]
   }
 
   describe "#tool_name" do
@@ -30,6 +31,11 @@ RSpec.describe QuietQuality::Tools::Rubocop::Runner do
   describe "#base_command" do
     subject(:base_command) { runner.base_command }
     it { is_expected.to eq(["rubocop", "-f", "json"]) }
+  end
+
+  describe "#base_exec_command" do
+    subject(:base_exec_command) { runner.base_exec_command }
+    it { is_expected.to eq(["rubocop"]) }
   end
 
   describe "#relevant_path?" do

--- a/spec/quiet_quality/tools/standardrb/runner_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/runner_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
     relevant: "foo.rb",
     irrelevant: "foo.ts",
     filter: /foo/,
-    base_command: ["standardrb", "-f", "json"]
+    base_command: ["standardrb", "-f", "json"],
+    base_exec_command: ["standardrb"]
   }
 
   describe "#tool_name" do
@@ -30,6 +31,11 @@ RSpec.describe QuietQuality::Tools::Standardrb::Runner do
   describe "#base_command" do
     subject(:base_command) { runner.base_command }
     it { is_expected.to eq(["standardrb", "-f", "json"]) }
+  end
+
+  describe "#base_exec_command" do
+    subject(:base_exec_command) { runner.base_exec_command }
+    it { is_expected.to eq(["standardrb"]) }
   end
 
   describe "#relevant_path?" do

--- a/spec/support/option_setup.rb
+++ b/spec/support/option_setup.rb
@@ -20,6 +20,7 @@ module OptionSetup
     maybe_set_option(opts, attrs, :colorize)
     maybe_set_option(opts, attrs, :annotator, :annotator_from)
     maybe_set_option(opts, attrs, :executor, :executor_from)
+    maybe_set_option(opts, attrs, :exec_tool)
     opts.tools = tool_options_from(attrs)
     opts
   end


### PR DESCRIPTION
In some cases the tools are slow enough that you don't _want_ to run them bundled together, or you want to see the normal output of a tool instead of the reformatted qq output. Of course, you can just run the tool _yourself_, but there's one main thing that `qq` does for you that's annoying to do yourself - working out which files to run it against.

This change adds a `--exec/-X TOOL` flag that allows you to let `qq` do the work to construct the command for you and then execute it, but instead of managing a flock of processes and merging/reformatting their output, it just _exec_s the command, and lets it handles its output.

For each runner, we specify/construct an `exec_command` (which is always currently the normal command, but without the 'give me json please' flags). If the Entrypoint gets the `exec` flag, it'll ignore any other tools it's told to run (whether by default, or because you listed them on the command-line), and just exec that tool with the flags it would normally run with. Keep in mind that many of the flags you can supply to `qq` will not matter, since we're not handling/parsing the output of the tool.

(This will resolve #105)