### PR TITLE
Make the fixes to comply with the current version of StandardRB

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,3 @@
+---
+format: progress
+ruby_version: 2.7

--- a/lib/quiet_quality.rb
+++ b/lib/quiet_quality.rb
@@ -16,7 +16,7 @@ module QuietQuality
   end
 end
 
-require_relative "./quiet_quality/logger"
-require_relative "./quiet_quality/logging"
+require_relative "quiet_quality/logger"
+require_relative "quiet_quality/logging"
 glob = File.expand_path("../quiet_quality/*.rb", __FILE__)
 Dir.glob(glob).sort.each { |f| require f }

--- a/lib/quiet_quality/cli.rb
+++ b/lib/quiet_quality/cli.rb
@@ -1,5 +1,5 @@
-require_relative "./annotators"
-require_relative "./tools"
+require_relative "annotators"
+require_relative "tools"
 
 module QuietQuality
   module Cli

--- a/lib/quiet_quality/executors/serial_executor.rb
+++ b/lib/quiet_quality/executors/serial_executor.rb
@@ -1,4 +1,4 @@
-require_relative "./base_executor"
+require_relative "base_executor"
 
 module QuietQuality
   module Executors

--- a/lib/quiet_quality/tools.rb
+++ b/lib/quiet_quality/tools.rb
@@ -8,8 +8,8 @@ module QuietQuality
   end
 end
 
-require_relative "./tools/base_runner"
-require_relative "./tools/relevant_runner"
+require_relative "tools/base_runner"
+require_relative "tools/relevant_runner"
 
 glob = File.expand_path("../tools/*.rb", __FILE__)
 Dir.glob(glob).sort.each { |f| require f }

--- a/lib/quiet_quality/tools/brakeman.rb
+++ b/lib/quiet_quality/tools/brakeman.rb
@@ -1,4 +1,4 @@
-require_relative "./rubocop"
+require_relative "rubocop"
 
 module QuietQuality
   module Tools

--- a/lib/quiet_quality/tools/relevant_runner.rb
+++ b/lib/quiet_quality/tools/relevant_runner.rb
@@ -1,4 +1,4 @@
-require_relative "./base_runner"
+require_relative "base_runner"
 
 module QuietQuality
   module Tools

--- a/lib/quiet_quality/tools/standardrb.rb
+++ b/lib/quiet_quality/tools/standardrb.rb
@@ -1,4 +1,4 @@
-require_relative "./rubocop"
+require_relative "rubocop"
 
 module QuietQuality
   module Tools

--- a/spec/quiet_quality/executors/base_executor_spec.rb
+++ b/spec/quiet_quality/executors/base_executor_spec.rb
@@ -1,4 +1,4 @@
-require_relative "./executor_examples"
+require_relative "executor_examples"
 
 RSpec.describe QuietQuality::Executors::BaseExecutor do
   let(:rspec_options) { tool_options(:rspec, limit_targets: true, filter_messages: false) }

--- a/spec/quiet_quality/executors/concurrent_executor_spec.rb
+++ b/spec/quiet_quality/executors/concurrent_executor_spec.rb
@@ -1,4 +1,4 @@
-require_relative "./executor_examples"
+require_relative "executor_examples"
 
 RSpec.describe QuietQuality::Executors::ConcurrentExecutor do
   let(:rspec_options) { tool_options(:rspec, limit_targets: true, filter_messages: false) }

--- a/spec/quiet_quality/executors/serial_executor_spec.rb
+++ b/spec/quiet_quality/executors/serial_executor_spec.rb
@@ -1,4 +1,4 @@
-require_relative "./executor_examples"
+require_relative "executor_examples"
 
 RSpec.describe QuietQuality::Executors::SerialExecutor do
   let(:rspec_options) { tool_options(:rspec, limit_targets: true, filter_messages: false) }

--- a/spec/quiet_quality/tools/base_runner_spec.rb
+++ b/spec/quiet_quality/tools/base_runner_spec.rb
@@ -1,4 +1,4 @@
-require_relative "./runner_examples"
+require_relative "runner_examples"
 
 RSpec.describe QuietQuality::Tools::BaseRunner do
   let(:changed_files) { instance_double(QuietQuality::ChangedFiles) }

--- a/spec/quiet_quality/tools/relevant_runner_spec.rb
+++ b/spec/quiet_quality/tools/relevant_runner_spec.rb
@@ -1,4 +1,4 @@
-require_relative "./runner_examples"
+require_relative "runner_examples"
 
 RSpec.describe QuietQuality::Tools::RelevantRunner do
   let(:changed_files) { nil }


### PR DESCRIPTION
It moves along without us, and I only find out when I make changes :-)

One of the new rules (`Style/ArgumentsForwarding`) is incompatible with any ruby before 3.2, so I'm specifying ruby 2.7 as the 'target ruby' for standardrb, since that's the earliest one we support. (That's their solution to that problem).