### PR TITLE
use checkout@v4 in all workflows

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -6,7 +6,7 @@ jobs:
   QuietQuality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,7 +6,7 @@ jobs:
   StandardRB:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -11,7 +11,7 @@ jobs:
         ruby-version: ['2.7', '3.0', '3.1', '3.2', 'head']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
use checkout@v4 in all workflows instead of checkout@v3 - should be no meaningful change for us.