### PR TITLE
Separate the file_filter/excludes handling properly

### DIFF
--- a/lib/quiet_quality/config/builder.rb
+++ b/lib/quiet_quality/config/builder.rb
@@ -129,7 +129,7 @@ module QuietQuality
           options.tools.each do |tool_options|
             update_tool_option(tool_options, :limit_targets)
             update_tool_option(tool_options, :filter_messages)
-            update_tool_option(tool_options, :file_filter)
+            set_unless_nil(tool_options, :file_filter, build_file_filter(tool_options.tool_name))
           end
         end
 
@@ -137,6 +137,13 @@ module QuietQuality
           tool_name = tool_options.tool_name
           set_unless_nil(tool_options, option_name, apply.global_option(option_name))
           set_unless_nil(tool_options, option_name, apply.tool_option(tool_name, option_name))
+        end
+
+        def build_file_filter(tool_name)
+          filter_string = apply.tool_option(tool_name, :file_filter)
+          excludes_strings = apply.tool_option(tool_name, :excludes)
+          return nil if filter_string.nil? && (excludes_strings.nil? || excludes_strings.empty?)
+          Config::FileFilter.new(regex: filter_string, excludes: excludes_strings)
         end
       end
     end

--- a/lib/quiet_quality/config/file_filter.rb
+++ b/lib/quiet_quality/config/file_filter.rb
@@ -8,6 +8,8 @@ module QuietQuality
         @excludes_strings = excludes
       end
 
+      attr_reader :regex_string, :excludes_strings
+
       def regex
         return nil if @regex_string.nil?
         @_regex ||= Regexp.new(@regex_string)
@@ -31,6 +33,10 @@ module QuietQuality
       # (b) either none of the excludes match or none are supplied
       def match?(s)
         regex_match?(s) && !excludes_match?(s)
+      end
+
+      def ==(other)
+        regex_string == other.regex_string && excludes_strings.sort == other.excludes_strings.sort
       end
 
       private

--- a/lib/quiet_quality/config/parsed_options.rb
+++ b/lib/quiet_quality/config/parsed_options.rb
@@ -21,7 +21,8 @@ module QuietQuality
       TOOL_OPTIONS = [
         :limit_targets,
         :filter_messages,
-        :file_filter
+        :file_filter,
+        :excludes
       ].to_set
 
       def initialize

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -413,7 +413,7 @@ RSpec.describe QuietQuality::Config::Builder do
           let(:file_filter) { QuietQuality::Config::FileFilter.new(regex: ".*", excludes: ["foo", "bar"]) }
 
           context "when the config file sets it" do
-            let(:cfg_tool_options) { {rspec: {file_filter: file_filter}} }
+            let(:cfg_tool_options) { {rspec: {file_filter: ".*", excludes: ["foo", "bar"]}} }
             it { is_expected.to eq(file_filter) }
           end
 

--- a/spec/quiet_quality/config/file_filter_spec.rb
+++ b/spec/quiet_quality/config/file_filter_spec.rb
@@ -116,4 +116,15 @@ RSpec.describe QuietQuality::Config::FileFilter do
       end
     end
   end
+
+  describe "==" do
+    let(:ff) { described_class.new(regex: "a", excludes: ["b", "c"]) }
+    let(:ff_same) { described_class.new(regex: "a", excludes: ["b", "c"]) }
+    let(:ff_different_order) { described_class.new(regex: "a", excludes: ["b", "c"]) }
+    let(:ff_different_values) { described_class.new(regex: "b", excludes: ["a", "c"]) }
+
+    specify { expect(ff).to eq(ff_same) }
+    specify { expect(ff).to eq(ff_different_order) }
+    specify { expect(ff).not_to eq(ff_different_values) }
+  end
 end

--- a/spec/quiet_quality/config/parser_spec.rb
+++ b/spec/quiet_quality/config/parser_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe QuietQuality::Config::Parser do
       )
 
       it "parsed the rspec file_filter properly" do
-        filter = parsed_options.tool_option("rspec", "file_filter")
-        expect(filter.regex).to eq(/spec\/.*_spec.rb/)
-        expect(filter.excludes).to contain_exactly(/^db\/schema\.rb/, /^db\/seeds\.rb/)
+        expect(parsed_options.tool_option("rspec", "file_filter")).to eq("spec/.*_spec.rb")
+        expect(parsed_options.tool_option("rspec", "excludes"))
+          .to contain_exactly("^db/schema\\.rb", "^db/seeds\\.rb")
       end
     end
 
@@ -158,9 +158,10 @@ RSpec.describe QuietQuality::Config::Parser do
           let(:yaml) { %({rspec: {file_filter: "^spec/"}}) }
 
           it "has the expected file_filters set" do
-            expect(parsed_options.tool_option("rspec", "file_filter").regex).to eq(/^spec\//)
-            expect(parsed_options.tool_option("rspec", "file_filter").excludes).to be_nil
+            expect(parsed_options.tool_option("rspec", "file_filter")).to eq("^spec/")
+            expect(parsed_options.tool_option("rspec", "excludes")).to be_nil
             expect(parsed_options.tool_option("rubocop", "file_filter")).to be_nil
+            expect(parsed_options.tool_option("rubocop", "excludes")).to be_nil
           end
         end
 
@@ -168,11 +169,16 @@ RSpec.describe QuietQuality::Config::Parser do
           let(:yaml) { %({rubocop: {excludes: ["foo", "bar"]}}) }
 
           it "has the expected file_filters set" do
-            expect(parsed_options.tool_option("rubocop", "file_filter").excludes).to contain_exactly(/foo/, /bar/)
-            expect(parsed_options.tool_option("rubocop", "file_filter").regex).to be_nil
+            expect(parsed_options.tool_option("rubocop", "excludes")).to contain_exactly("foo", "bar")
+            expect(parsed_options.tool_option("rubocop", "file_filter")).to be_nil
+            expect(parsed_options.tool_option("rspec", "excludes")).to be_nil
             expect(parsed_options.tool_option("rspec", "file_filter")).to be_nil
           end
         end
+
+        expect_invalid "an invalid tool file_filter", %({rspec: {file_filter: 2}}), /must be a string/
+        expect_invalid "an invalid tool excludes", %({rspec: {excludes: "foo"}}), /must be an array/
+        expect_invalid "an invalid tool excludes", %({rspec: {excludes: ["a",2]}}), /must be a string/
       end
     end
   end


### PR DESCRIPTION
When we added the file-filtering system as a config-file-only feature, we didn't follow the design strategy used by the other options thoroughly - the Config::FileFilter object was getting built in the Config::Parser and attached to the ParsedOptions, while the _other_ options were all processed minimally there.

We're about to add cli-based file-filtering/exclusion, and replicating that construction into the ArgParser seems wrong. This PR refactors the existing Config::Parser to just attach a `file_filter` string an an array of `excludes` strings to the ParsedOptions object, and relies on the Config::Builder to turn those into a Config::FileFilter later (which makes that bit automatically reusable).

No behavioral difference should be present in this slice - it's a refactor that makes the addition of the cli arguments for tool-specific file filter/excludes easier in the next slice.