### PR TITLE
When brakeman produces errors, expose those errors (fixes #115)

### DIFF
--- a/lib/quiet_quality/tools/brakeman/parser.rb
+++ b/lib/quiet_quality/tools/brakeman/parser.rb
@@ -2,6 +2,8 @@ module QuietQuality
   module Tools
     module Brakeman
       class Parser
+        include Logging
+
         def initialize(text)
           @text = text
         end
@@ -24,6 +26,8 @@ module QuietQuality
         def check_errors!
           errors = data[:errors]
           return if errors.nil? || errors.empty?
+          warn "Brakeman errors:"
+          errors.each { |error| warn "    #{error}" }
           fail(ParsingError, "Found #{errors.length} errors in brakeman output")
         end
 

--- a/spec/quiet_quality/tools/brakeman/parser_spec.rb
+++ b/spec/quiet_quality/tools/brakeman/parser_spec.rb
@@ -40,11 +40,14 @@ RSpec.describe QuietQuality::Tools::Brakeman::Parser do
     context "when there are errors" do
       let(:text) { fixture_content("tools", "brakeman", "errors.json") }
 
-      it "raises a ParsingError" do
+      it "raises a ParsingError and logs the errors" do
         expect { messages }.to raise_error(
           QuietQuality::Tools::ParsingError,
           /Found 2 errors/
         )
+        expect_warn "Brakeman errors:"
+        expect_warn "    Something went wrong"
+        expect_warn "    Something else too"
       end
     end
   end


### PR DESCRIPTION
Instead of just failing and telling us there _were_ some errors, expose what they were in a readable way (by printing them as logger `warn` statements).

This will result in the base experience of `qq brakeman` (in the problem case of #115) being much more pleasant, as the actual error messages will just print by default.

Fixes #115, hopefully