### PR TITLE
Allow command/exec_command overrides via yaml config

### DIFF
--- a/lib/quiet_quality/config/builder.rb
+++ b/lib/quiet_quality/config/builder.rb
@@ -129,13 +129,14 @@ module QuietQuality
           options.tools.each do |tool_options|
             update_tool_option(tool_options, :limit_targets)
             update_tool_option(tool_options, :filter_messages)
+            update_tool_option(tool_options, :command, global: false)
             set_unless_nil(tool_options, :file_filter, build_file_filter(tool_options.tool_name))
           end
         end
 
-        def update_tool_option(tool_options, option_name)
+        def update_tool_option(tool_options, option_name, global: true)
           tool_name = tool_options.tool_name
-          set_unless_nil(tool_options, option_name, apply.global_option(option_name))
+          set_unless_nil(tool_options, option_name, apply.global_option(option_name)) if global
           set_unless_nil(tool_options, option_name, apply.tool_option(tool_name, option_name))
         end
 

--- a/lib/quiet_quality/config/builder.rb
+++ b/lib/quiet_quality/config/builder.rb
@@ -130,6 +130,7 @@ module QuietQuality
             update_tool_option(tool_options, :limit_targets)
             update_tool_option(tool_options, :filter_messages)
             update_tool_option(tool_options, :command, global: false)
+            update_tool_option(tool_options, :exec_command, global: false)
             set_unless_nil(tool_options, :file_filter, build_file_filter(tool_options.tool_name))
           end
         end

--- a/lib/quiet_quality/config/parsed_options.rb
+++ b/lib/quiet_quality/config/parsed_options.rb
@@ -22,7 +22,8 @@ module QuietQuality
         :limit_targets,
         :filter_messages,
         :file_filter,
-        :excludes
+        :excludes,
+        :command
       ].to_set
 
       def initialize

--- a/lib/quiet_quality/config/parsed_options.rb
+++ b/lib/quiet_quality/config/parsed_options.rb
@@ -23,7 +23,8 @@ module QuietQuality
         :filter_messages,
         :file_filter,
         :excludes,
-        :command
+        :command,
+        :exec_command
       ].to_set
 
       def initialize

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -67,6 +67,7 @@ module QuietQuality
         read_tool_option(opts, tool_name, :all_files, :limit_targets, as: :reversed_boolean)
         read_tool_option(opts, tool_name, :file_filter, :file_filter, as: :string)
         read_tool_option(opts, tool_name, :excludes, :excludes, as: :strings)
+        read_tool_option(opts, tool_name, :command, :command, as: :strings)
       end
 
       def invalid!(message)

--- a/lib/quiet_quality/config/parser.rb
+++ b/lib/quiet_quality/config/parser.rb
@@ -68,6 +68,7 @@ module QuietQuality
         read_tool_option(opts, tool_name, :file_filter, :file_filter, as: :string)
         read_tool_option(opts, tool_name, :excludes, :excludes, as: :strings)
         read_tool_option(opts, tool_name, :command, :command, as: :strings)
+        read_tool_option(opts, tool_name, :exec_command, :exec_command, as: :strings)
       end
 
       def invalid!(message)

--- a/lib/quiet_quality/config/tool_options.rb
+++ b/lib/quiet_quality/config/tool_options.rb
@@ -1,15 +1,16 @@
 module QuietQuality
   module Config
     class ToolOptions
-      def initialize(tool, limit_targets: true, filter_messages: true, file_filter: nil, command: nil)
+      def initialize(tool, **options)
         @tool_name = tool.to_sym
-        @limit_targets = limit_targets
-        @filter_messages = filter_messages
-        @file_filter = file_filter
-        @command = command
+        @limit_targets = options.fetch(:limit_targets, true)
+        @filter_messages = options.fetch(:filter_messages, true)
+        @file_filter = options.fetch(:file_filter, nil)
+        @command = options.fetch(:command, nil)
+        @exec_command = options.fetch(:exec_command, nil)
       end
 
-      attr_accessor :file_filter, :command
+      attr_accessor :file_filter, :command, :exec_command
       attr_reader :tool_name
       attr_writer :limit_targets, :filter_messages
 
@@ -40,6 +41,7 @@ module QuietQuality
           filter_messages: filter_messages?,
           file_filter: file_filter&.regex&.to_s,
           command: command,
+          exec_command: exec_command,
           excludes: file_filter&.excludes&.map(&:to_s)
         }
       end

--- a/lib/quiet_quality/config/tool_options.rb
+++ b/lib/quiet_quality/config/tool_options.rb
@@ -1,14 +1,15 @@
 module QuietQuality
   module Config
     class ToolOptions
-      def initialize(tool, limit_targets: true, filter_messages: true, file_filter: nil)
+      def initialize(tool, limit_targets: true, filter_messages: true, file_filter: nil, command: nil)
         @tool_name = tool.to_sym
         @limit_targets = limit_targets
         @filter_messages = filter_messages
         @file_filter = file_filter
+        @command = command
       end
 
-      attr_accessor :file_filter
+      attr_accessor :file_filter, :command
       attr_reader :tool_name
       attr_writer :limit_targets, :filter_messages
 
@@ -38,6 +39,7 @@ module QuietQuality
           limit_targets: limit_targets?,
           filter_messages: filter_messages?,
           file_filter: file_filter&.regex&.to_s,
+          command: command,
           excludes: file_filter&.excludes&.map(&:to_s)
         }
       end

--- a/lib/quiet_quality/executors/execcer.rb
+++ b/lib/quiet_quality/executors/execcer.rb
@@ -32,7 +32,9 @@ module QuietQuality
       def runner
         @_runner ||= tool_options.runner_class.new(
           changed_files: limit_targets? ? changed_files : nil,
-          file_filter: tool_options.file_filter
+          file_filter: tool_options.file_filter,
+          command_override: tool_options.command,
+          exec_override: tool_options.exec_command
         ).tap { |r| log_runner(r) }
       end
 

--- a/lib/quiet_quality/executors/pipeline.rb
+++ b/lib/quiet_quality/executors/pipeline.rb
@@ -49,7 +49,9 @@ module QuietQuality
       def runner
         @_runner ||= tool_options.runner_class.new(
           changed_files: limit_targets? ? changed_files : nil,
-          file_filter: tool_options.file_filter
+          file_filter: tool_options.file_filter,
+          command_override: tool_options.command,
+          exec_override: tool_options.exec_command
         ).tap { |r| log_runner(r) }
       end
 

--- a/lib/quiet_quality/tools/base_runner.rb
+++ b/lib/quiet_quality/tools/base_runner.rb
@@ -6,9 +6,11 @@ module QuietQuality
       # In general, we don't want to supply a huge number of arguments to a command-line tool.
       MAX_FILES = 100
 
-      def initialize(changed_files: nil, file_filter: nil)
+      def initialize(changed_files: nil, file_filter: nil, command_override: nil, exec_override: nil)
         @changed_files = changed_files
         @file_filter = file_filter
+        @command_override = command_override
+        @exec_override = exec_override
       end
 
       def invoke!
@@ -38,7 +40,7 @@ module QuietQuality
 
       private
 
-      attr_reader :changed_files, :file_filter
+      attr_reader :changed_files, :file_filter, :command_override, :exec_override
 
       def performed_outcome
         out, err, stat = Open3.capture3(*command)

--- a/lib/quiet_quality/tools/brakeman/runner.rb
+++ b/lib/quiet_quality/tools/brakeman/runner.rb
@@ -7,11 +7,11 @@ module QuietQuality
         end
 
         def command
-          ["brakeman", "-f", "json"]
+          command_override || ["brakeman", "-f", "json"]
         end
 
         def exec_command
-          ["brakeman"]
+          exec_override || ["brakeman"]
         end
 
         # These are specified in constants at the top of brakeman.rb:

--- a/lib/quiet_quality/tools/markdown_lint/runner.rb
+++ b/lib/quiet_quality/tools/markdown_lint/runner.rb
@@ -12,21 +12,26 @@ module QuietQuality
 
         def command(json: true)
           return nil if skip_execution?
-          base_command = ["mdl"]
-          base_command << "--json" if json
-          if target_files.any?
-            base_command + target_files.sort
-          else
-            base_command + ["."]
-          end
+          (command_override || ["mdl", "--json"]) + command_targets
         end
 
         def exec_command
-          command(json: false)
+          return nil if skip_execution?
+          (exec_override || ["mdl"]) + command_targets
         end
 
         def relevant_path?(path)
           path.end_with?(".md")
+        end
+
+        private
+
+        def command_targets
+          if target_files.any?
+            target_files.sort
+          else
+            ["."]
+          end
         end
       end
     end

--- a/lib/quiet_quality/tools/relevant_runner.rb
+++ b/lib/quiet_quality/tools/relevant_runner.rb
@@ -13,12 +13,12 @@ module QuietQuality
 
       def command
         return nil if skip_execution?
-        base_command + target_files.sort
+        (command_override || base_command) + target_files.sort
       end
 
       def exec_command
         return nil if skip_execution?
-        base_exec_command + target_files.sort
+        (exec_override || base_exec_command) + target_files.sort
       end
 
       def relevant_path?(path)

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -423,6 +423,29 @@ RSpec.describe QuietQuality::Config::Builder do
           end
         end
       end
+
+      describe "#command" do
+        let(:rspec_tool_option) { tools.detect { |t| t.tool_name == :rspec } }
+        subject(:rspec_command) { rspec_tool_option.command }
+
+        context "with no config file supplied" do
+          it { is_expected.to be_nil }
+        end
+
+        context "with a config file supplied" do
+          let(:global_options) { {config_path: "fake.yml"} }
+
+          context "when the config file sets it" do
+            let(:cfg_tool_options) { {rspec: {command: ["a", "b"]}} }
+            it { is_expected.to eq(["a", "b"]) }
+          end
+
+          context "when the config file does not set it" do
+            let(:cfg_tool_options) { {rspec: {filter_messages: false}} }
+            it { is_expected.to be_nil }
+          end
+        end
+      end
     end
 
     describe "config_file parsing" do

--- a/spec/quiet_quality/config/builder_spec.rb
+++ b/spec/quiet_quality/config/builder_spec.rb
@@ -446,6 +446,29 @@ RSpec.describe QuietQuality::Config::Builder do
           end
         end
       end
+
+      describe "#exec_command" do
+        let(:rspec_tool_option) { tools.detect { |t| t.tool_name == :rspec } }
+        subject(:rspec_exec_command) { rspec_tool_option.exec_command }
+
+        context "with no config file supplied" do
+          it { is_expected.to be_nil }
+        end
+
+        context "with a config file supplied" do
+          let(:global_options) { {config_path: "fake.yml"} }
+
+          context "when the config file sets it" do
+            let(:cfg_tool_options) { {rspec: {exec_command: ["a", "b"]}} }
+            it { is_expected.to eq(["a", "b"]) }
+          end
+
+          context "when the config file does not set it" do
+            let(:cfg_tool_options) { {rspec: {filter_messages: false}} }
+            it { is_expected.to be_nil }
+          end
+        end
+      end
     end
 
     describe "config_file parsing" do

--- a/spec/quiet_quality/config/options_spec.rb
+++ b/spec/quiet_quality/config/options_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe QuietQuality::Config::Options do
             excludes: nil,
             filter_messages: true,
             command: nil,
+            exec_command: nil,
             limit_targets: true
           },
           standardrb: {
@@ -108,6 +109,7 @@ RSpec.describe QuietQuality::Config::Options do
             excludes: nil,
             filter_messages: false,
             command: nil,
+            exec_command: nil,
             limit_targets: true
           }
         }

--- a/spec/quiet_quality/config/options_spec.rb
+++ b/spec/quiet_quality/config/options_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe QuietQuality::Config::Options do
             file_filter: nil,
             excludes: nil,
             filter_messages: true,
+            command: nil,
             limit_targets: true
           },
           standardrb: {
@@ -106,6 +107,7 @@ RSpec.describe QuietQuality::Config::Options do
             file_filter: nil,
             excludes: nil,
             filter_messages: false,
+            command: nil,
             limit_targets: true
           }
         }

--- a/spec/quiet_quality/config/parser_spec.rb
+++ b/spec/quiet_quality/config/parser_spec.rb
@@ -180,6 +180,28 @@ RSpec.describe QuietQuality::Config::Parser do
         expect_invalid "an invalid tool excludes", %({rspec: {excludes: "foo"}}), /must be an array/
         expect_invalid "an invalid tool excludes", %({rspec: {excludes: ["a",2]}}), /must be a string/
       end
+
+      describe "command parsing" do
+        expect_config "no settings", %({}), tools: {rspec: {command: nil}, rubocop: {command: nil}}
+
+        context "with a config that has an rspec command supplied" do
+          let(:yaml) { %({rspec: {command: ["foo", "bar", "baz"]}}) }
+
+          it "has the expected commands set" do
+            expect(parsed_options.tool_option("rspec", "command")).to eq(["foo", "bar", "baz"])
+            expect(parsed_options.tool_option("rubocop", "command")).to be_nil
+          end
+        end
+
+        context "with multiple configs with commands supplied" do
+          let(:yaml) { %({rspec: {command: ["a", "b"]}, rubocop: {command: ["c", "d"]}}) }
+
+          it "has the expected commands set" do
+            expect(parsed_options.tool_option("rspec", "command")).to eq(["a", "b"])
+            expect(parsed_options.tool_option("rubocop", "command")).to eq(["c", "d"])
+          end
+        end
+      end
     end
   end
 end

--- a/spec/quiet_quality/config/parser_spec.rb
+++ b/spec/quiet_quality/config/parser_spec.rb
@@ -202,6 +202,28 @@ RSpec.describe QuietQuality::Config::Parser do
           end
         end
       end
+
+      describe "exec_command parsing" do
+        expect_config "no settings", %({}), tools: {rspec: {exec_command: nil}, rubocop: {exec_command: nil}}
+
+        context "with a config that has an rspec exec_command supplied" do
+          let(:yaml) { %({rspec: {exec_command: ["foo", "bar", "baz"]}}) }
+
+          it "has the expected exec_commands set" do
+            expect(parsed_options.tool_option("rspec", "exec_command")).to eq(["foo", "bar", "baz"])
+            expect(parsed_options.tool_option("rubocop", "exec_command")).to be_nil
+          end
+        end
+
+        context "with multiple configs with exec_commands supplied" do
+          let(:yaml) { %({rspec: {exec_command: ["a", "b"]}, rubocop: {exec_command: ["c", "d"]}}) }
+
+          it "has the expected exec_commands set" do
+            expect(parsed_options.tool_option("rspec", "exec_command")).to eq(["a", "b"])
+            expect(parsed_options.tool_option("rubocop", "exec_command")).to eq(["c", "d"])
+          end
+        end
+      end
     end
   end
 end

--- a/spec/quiet_quality/config/tool_options_spec.rb
+++ b/spec/quiet_quality/config/tool_options_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe QuietQuality::Config::ToolOptions do
 
     context "with all attributes supplied" do
       let(:file_filter) { QuietQuality::Config::FileFilter.new(regex: /^foo.*$/i, excludes: [/foo/, /bar/]) }
-      let(:tool_options) { described_class.new(:rspec, limit_targets: true, filter_messages: false, file_filter: file_filter) }
+      let(:tool_options) { described_class.new(:rspec, limit_targets: true, filter_messages: false, command: ["a", "b"], file_filter: file_filter) }
 
       it "produces the expected hash" do
         expect(to_h).to eq({
@@ -58,6 +58,7 @@ RSpec.describe QuietQuality::Config::ToolOptions do
           limit_targets: true,
           filter_messages: false,
           file_filter: "(?i-mx:^foo.*$)",
+          command: ["a", "b"],
           excludes: ["(?-mix:foo)", "(?-mix:bar)"]
         })
       end
@@ -72,6 +73,7 @@ RSpec.describe QuietQuality::Config::ToolOptions do
           limit_targets: true,
           filter_messages: false,
           file_filter: nil,
+          command: nil,
           excludes: nil
         })
       end

--- a/spec/quiet_quality/config/tool_options_spec.rb
+++ b/spec/quiet_quality/config/tool_options_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe QuietQuality::Config::ToolOptions do
 
     context "with all attributes supplied" do
       let(:file_filter) { QuietQuality::Config::FileFilter.new(regex: /^foo.*$/i, excludes: [/foo/, /bar/]) }
-      let(:tool_options) { described_class.new(:rspec, limit_targets: true, filter_messages: false, command: ["a", "b"], file_filter: file_filter) }
+      let(:tool_options) { described_class.new(:rspec, limit_targets: true, filter_messages: false, command: ["a", "b"], exec_command: ["c", "d"], file_filter: file_filter) }
 
       it "produces the expected hash" do
         expect(to_h).to eq({
@@ -59,6 +59,7 @@ RSpec.describe QuietQuality::Config::ToolOptions do
           filter_messages: false,
           file_filter: "(?i-mx:^foo.*$)",
           command: ["a", "b"],
+          exec_command: ["c", "d"],
           excludes: ["(?-mix:foo)", "(?-mix:bar)"]
         })
       end
@@ -74,6 +75,7 @@ RSpec.describe QuietQuality::Config::ToolOptions do
           filter_messages: false,
           file_filter: nil,
           command: nil,
+          exec_command: nil,
           excludes: nil
         })
       end

--- a/spec/quiet_quality/executors/execcer_spec.rb
+++ b/spec/quiet_quality/executors/execcer_spec.rb
@@ -2,7 +2,9 @@ RSpec.describe QuietQuality::Executors::Execcer do
   let(:limit_targets?) { true }
   let(:file_filter) { ".*" }
   let(:tool_name) { :rspec }
-  let(:tool_opts) { tool_options(tool_name, limit_targets: limit_targets?, file_filter: file_filter) }
+  let(:command_override) { ["my", "command"] }
+  let(:exec_override) { ["my", "exec"] }
+  let(:tool_opts) { tool_options(tool_name, limit_targets: limit_targets?, file_filter: file_filter, command: command_override, exec_command: exec_override) }
 
   let(:foo_file) { QuietQuality::ChangedFile.new(path: "path/foo.rb", lines: [1, 2, 3, 5, 10]) }
   let(:bar_file) { QuietQuality::ChangedFile.new(path: "path/bar.rb", lines: [5, 6, 7, 14, 15]) }
@@ -27,9 +29,12 @@ RSpec.describe QuietQuality::Executors::Execcer do
 
       it "sets up the runner correctly" do
         exec!
-        expect(runner_class)
-          .to have_received(:new)
-          .with(changed_files: changed_files, file_filter: file_filter)
+        expect(runner_class).to have_received(:new).with(
+          changed_files: changed_files,
+          file_filter: file_filter,
+          command_override: command_override,
+          exec_override: exec_override
+        )
       end
 
       it "logs correctly", aggregate_failures: true do
@@ -50,9 +55,12 @@ RSpec.describe QuietQuality::Executors::Execcer do
 
       it "sets up the runner correctly" do
         exec!
-        expect(runner_class)
-          .to have_received(:new)
-          .with(changed_files: nil, file_filter: file_filter)
+        expect(runner_class).to have_received(:new).with(
+          changed_files: nil,
+          file_filter: file_filter,
+          command_override: command_override,
+          exec_override: exec_override
+        )
       end
 
       it "logs correctly", aggregate_failures: true do
@@ -74,9 +82,12 @@ RSpec.describe QuietQuality::Executors::Execcer do
 
       it "sets up the runner correctly" do
         exec!
-        expect(runner_class)
-          .to have_received(:new)
-          .with(changed_files: changed_files, file_filter: file_filter)
+        expect(runner_class).to have_received(:new).with(
+          changed_files: changed_files,
+          file_filter: file_filter,
+          command_override: command_override,
+          exec_override: exec_override
+        )
       end
 
       it "logs correctly", aggregate_failures: true do

--- a/spec/quiet_quality/executors/pipeline_spec.rb
+++ b/spec/quiet_quality/executors/pipeline_spec.rb
@@ -1,8 +1,10 @@
 RSpec.describe QuietQuality::Executors::Pipeline do
   let(:limit_targets?) { true }
   let(:filter_messages?) { true }
+  let(:command_override) { ["my", "command"] }
+  let(:exec_override) { ["my", "exec"] }
   let(:tool_name) { :rspec }
-  let(:tool_opts) { tool_options(tool_name, limit_targets: limit_targets?, filter_messages: filter_messages?, file_filter: ".*") }
+  let(:tool_opts) { tool_options(tool_name, limit_targets: limit_targets?, filter_messages: filter_messages?, file_filter: ".*", command: command_override, exec_command: exec_override) }
 
   let(:foo_file) { QuietQuality::ChangedFile.new(path: "path/foo.rb", lines: [1, 2, 3, 5, 10]) }
   let(:bar_file) { QuietQuality::ChangedFile.new(path: "path/bar.rb", lines: [5, 6, 7, 14, 15]) }
@@ -44,7 +46,9 @@ RSpec.describe QuietQuality::Executors::Pipeline do
         outcome
         expect(runner_class).to have_received(:new).with(
           changed_files: changed_files,
-          file_filter: /.*/
+          file_filter: /.*/,
+          command_override: command_override,
+          exec_override: exec_override
         )
       end
     end
@@ -56,7 +60,9 @@ RSpec.describe QuietQuality::Executors::Pipeline do
         outcome
         expect(runner_class).to have_received(:new).with(
           changed_files: nil,
-          file_filter: /.*/
+          file_filter: /.*/,
+          command_override: command_override,
+          exec_override: exec_override
         )
       end
     end

--- a/spec/quiet_quality/tools/brakeman/runner_spec.rb
+++ b/spec/quiet_quality/tools/brakeman/runner_spec.rb
@@ -12,11 +12,21 @@ RSpec.describe QuietQuality::Tools::Brakeman::Runner do
   describe "#command" do
     subject(:command) { runner.command }
     it { is_expected.to eq(["brakeman", "-f", "json"]) }
+
+    context "with a command_override supplied" do
+      let(:runner) { described_class.new(command_override: ["brakeman", "--foo"]) }
+      it { is_expected.to eq(["brakeman", "--foo"]) }
+    end
   end
 
   describe "#exec_command" do
     subject(:exec_command) { runner.exec_command }
     it { is_expected.to eq(["brakeman"]) }
+
+    context "with an exec_override supplied" do
+      let(:runner) { described_class.new(exec_override: ["brakeman", "--foo"]) }
+      it { is_expected.to eq(["brakeman", "--foo"]) }
+    end
   end
 
   it_behaves_like "a functional BaseRunner subclass", :brakeman, failure: (3..8) do


### PR DESCRIPTION
This allows one to accommodate a lot of atypical situations, where rspec (for example) needs to be supplied with additional arguments (like a load path, a pattern, etc).

We do not yet support supplying this configuration on the CLI, but each tool may supply a `command` and/or `exec_command` value in the yaml config. If it does, that will be used instead of the built-in command (note that RelevantRunner will still suffix the list of files in the usual cases).

Updating your config file to add `rspec: { exec_command: ["rspec", "-f", "d"] }` for example will make `qq -Xrspec` run in documentation format. Though that's a lot of output in most test suites :-)