### PR TITLE
Update git gem constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 *.gem
 coverage/
 tmp/*
+.DS_Store

--- a/quiet_quality.gemspec
+++ b/quiet_quality.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
       .map { |path| path.sub(/^bin\//, "") }
   end
 
-  spec.add_dependency "git", "~> 1.18"
+  spec.add_dependency "git", ">= 1.18"
   spec.add_dependency "git_diff_parser", "~> 4"
 
   spec.add_development_dependency "rspec", "~> 3.13"


### PR DESCRIPTION
This resolve this issue https://github.com/nevinera/quiet_quality/issues/129

The full changelog for git gem can be found [here](https://github.com/ruby-git/ruby-git/blob/master/CHANGELOG.md).

While I was making my change I also added to the `.gitignore` to ensure `.DS_Store` never gets added to the repo 😄  