### PR TITLE
fix: left-justified 'tool' in format-strings works

### DIFF
--- a/lib/quiet_quality/cli/message_formatter.rb
+++ b/lib/quiet_quality/cli/message_formatter.rb
@@ -120,7 +120,7 @@ module QuietQuality
           end
         end
 
-        def base_string
+        def base_value
           case parsed_token.source
           when "tool" then message.tool_name
           when "loc" then location_string
@@ -129,7 +129,11 @@ module QuietQuality
           when "lines" then line_range
           when "rule" then message.rule
           when "body" then flattened_body
-          end.to_s
+          end
+        end
+
+        def base_string
+          base_value.to_s
         end
 
         def location_string

--- a/lib/quiet_quality/cli/message_formatter.rb
+++ b/lib/quiet_quality/cli/message_formatter.rb
@@ -129,7 +129,7 @@ module QuietQuality
           when "lines" then line_range
           when "rule" then message.rule
           when "body" then flattened_body
-          end
+          end.to_s
         end
 
         def location_string

--- a/spec/quiet_quality/cli/message_formatter_spec.rb
+++ b/spec/quiet_quality/cli/message_formatter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe QuietQuality::Cli::MessageFormatter do
   describe "#format" do
     let(:message) do
       generate_message(
-        tool_name: "fake_tool",
+        tool_name: :fake_tool,
         path: "path/to/the/file.rb",
         start_line: 5,
         stop_line: stop_line,


### PR DESCRIPTION
## Problem

```
qq -E serial rspec -n

quiet_quality/lib/quiet_quality/cli/message_formatter.rb:174:in `padded': undefined method `ljust' for an instance of Symbol (NoMethodError)

          when :left then s.ljust(parsed_token.size)
                           ^^^^^^
        from /Users/albrights/src/quiet_quality/lib/quiet_quality/cli/message_formatter.rb:104:in `formatted_token'
```

## Investigation

The Message object exposes the 'tool' as _whatever was supplied_, which is a Symbol in all cases. But the formatting logic treated everything it attempted to format as strings, and some of the methods it calls on them aren't available for symbols.

## Solution

Update the MessageFormater to `to_s` the value from `base_string`, ensuring that it is in fact a String.