### PR TITLE
fix: skip past the _updated_ simplecov output when parsing rspec

### DIFF
--- a/lib/quiet_quality/tools/rspec/parser.rb
+++ b/lib/quiet_quality/tools/rspec/parser.rb
@@ -32,8 +32,9 @@ module QuietQuality
         # stdout - we probably won't worry about any but the most common.
         def cleaned_text
           @_cleaned_text ||= text
-            .gsub(/Coverage report generated.*covered.$/, "")
-            .gsub(/Encoding problems with file.*$/, "")
+            .sub(/}Coverage report generated.*/m, "}\n")
+            .gsub(/^Encoding problems with file.*$/, "")
+            .gsub(/}Encoding problems with file.*$/, "}")
         end
 
         def content

--- a/spec/fixtures/tools/rspec/no-failures.updated-simplecov.json
+++ b/spec/fixtures/tools/rspec/no-failures.updated-simplecov.json
@@ -1,0 +1,45 @@
+{
+  "version": "3.12.2",
+  "seed": 64304,
+  "examples": [
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:3:2]",
+      "description": "calls standardrb correctly, with no targets",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full and contains too many ruby files calls standardrb correctly, with no targets",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 75,
+      "run_time": 0.000185,
+      "pending_message": null
+    },
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:1:1]",
+      "description": "does not call standardrb",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full but contains no ruby files does not call standardrb",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 54,
+      "run_time": 0.000125,
+      "pending_message": null
+    },
+    {
+      "id": "./spec/quiet_quality/tools/standardrb/runner_spec.rb[1:1:4:2:2]",
+      "description": "calls standardrb correctly, with changed and relevant targets",
+      "full_description": "QuietQuality::Tools::Standardrb::Runner#invoke! when changed_files is full and contains some ruby files calls standardrb correctly, with changed and relevant targets",
+      "status": "passed",
+      "file_path": "./spec/quiet_quality/tools/standardrb/runner_spec.rb",
+      "line_number": 63,
+      "run_time": 0.000148,
+      "pending_message": null
+    }
+  ],
+  "summary": {
+    "duration": 0.018751,
+    "example_count": 3,
+    "failure_count": 0,
+    "pending_count": 0,
+    "errors_outside_of_examples_count": 0
+  },
+  "summary_line": "89 examples, 0 failures"
+}Coverage report generated for RSpec to /Users/albrights/src/quiet_quality/coverage.
+Line Coverage: 100.0% (1403 / 1403)

--- a/spec/quiet_quality/tools/rspec/parser_spec.rb
+++ b/spec/quiet_quality/tools/rspec/parser_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe QuietQuality::Tools::Rspec::Parser do
       it { is_expected.to be_empty }
     end
 
+    context "when simplecov dumps *updated* non-json results output into the stream" do
+      let(:text) { fixture_content("tools", "rspec", "no-failures.updated-simplecov.json") }
+      it { is_expected.to be_a(QuietQuality::Messages) }
+      it { is_expected.to be_empty }
+    end
+
     context "when simplecov dumps multiple filename encoding problems into the stream" do
       let(:text) { fixture_content("tools", "rspec", "no-failures.with-simplecov-encoding-errors.json") }
       it { is_expected.to be_a(QuietQuality::Messages) }


### PR DESCRIPTION
When you enable simplecov, it writes plain text to stdout, *even if rspec is running with `--format json`*. We have regexes to skip over this plaintext (I _knew_ this issue seemed familiar..), but they _updated_ it at some point, and our regexes stopped matching.

Improve the regex to match both styles. Ideally, we'd use a json-parser that knows how to skip all the junk at the end, but I haven't found one yet (we'll adopt it if I do)

Fixes #131 