### PR TITLE
Handle and expose simplecov coverage failures

### DIFF
--- a/lib/quiet_quality/executors/pipeline.rb
+++ b/lib/quiet_quality/executors/pipeline.rb
@@ -62,7 +62,7 @@ module QuietQuality
       end
 
       def parser
-        @_parser ||= tool_options.parser_class.new(runner_outcome.output)
+        @_parser ||= tool_options.parser_class.new(runner_outcome.output, tool_options: tool_options)
       end
 
       def relevance_filter

--- a/lib/quiet_quality/executors/pipeline.rb
+++ b/lib/quiet_quality/executors/pipeline.rb
@@ -17,7 +17,8 @@ module QuietQuality
           tool: runner_outcome.tool,
           output: runner_outcome.output,
           logging: runner_outcome.logging,
-          failure: messages.any?
+          failure: messages.any?,
+          exit_status: runner_outcome.exit_status
         )
       end
 

--- a/lib/quiet_quality/executors/pipeline.rb
+++ b/lib/quiet_quality/executors/pipeline.rb
@@ -63,7 +63,7 @@ module QuietQuality
       end
 
       def parser
-        @_parser ||= tool_options.parser_class.new(runner_outcome.output, tool_options: tool_options)
+        @_parser ||= tool_options.parser_class.new(runner_outcome, tool_options: tool_options)
       end
 
       def relevance_filter

--- a/lib/quiet_quality/tools/base_runner.rb
+++ b/lib/quiet_quality/tools/base_runner.rb
@@ -47,9 +47,9 @@ module QuietQuality
         log_performance(err, stat)
 
         if success_status?(stat)
-          Outcome.new(tool: tool_name, output: out, logging: err)
+          Outcome.new(tool: tool_name, output: out, logging: err, exit_status: stat.exitstatus)
         elsif failure_status?(stat)
-          Outcome.new(tool: tool_name, output: out, logging: err, failure: true)
+          Outcome.new(tool: tool_name, output: out, logging: err, failure: true, exit_status: stat.exitstatus)
         else
           fail(ExecutionError, "Execution of #{tool_name} failed with #{stat.exitstatus}")
         end

--- a/lib/quiet_quality/tools/brakeman/parser.rb
+++ b/lib/quiet_quality/tools/brakeman/parser.rb
@@ -4,8 +4,9 @@ module QuietQuality
       class Parser
         include Logging
 
-        def initialize(text)
+        def initialize(text, tool_options:)
           @text = text
+          @tool_options = tool_options
         end
 
         def messages

--- a/lib/quiet_quality/tools/brakeman/parser.rb
+++ b/lib/quiet_quality/tools/brakeman/parser.rb
@@ -4,8 +4,8 @@ module QuietQuality
       class Parser
         include Logging
 
-        def initialize(text, tool_options:)
-          @text = text
+        def initialize(outcome, tool_options:)
+          @outcome = outcome
           @tool_options = tool_options
         end
 
@@ -18,7 +18,11 @@ module QuietQuality
 
         private
 
-        attr_reader :text
+        attr_reader :outcome
+
+        def text
+          outcome.output
+        end
 
         def data
           @_data ||= JSON.parse(text, symbolize_names: true)

--- a/lib/quiet_quality/tools/haml_lint/parser.rb
+++ b/lib/quiet_quality/tools/haml_lint/parser.rb
@@ -2,8 +2,9 @@ module QuietQuality
   module Tools
     module HamlLint
       class Parser
-        def initialize(text)
+        def initialize(text, tool_options:)
           @text = text
+          @tool_options = tool_options
         end
 
         def messages

--- a/lib/quiet_quality/tools/haml_lint/parser.rb
+++ b/lib/quiet_quality/tools/haml_lint/parser.rb
@@ -2,8 +2,8 @@ module QuietQuality
   module Tools
     module HamlLint
       class Parser
-        def initialize(text, tool_options:)
-          @text = text
+        def initialize(outcome, tool_options:)
+          @outcome = outcome
           @tool_options = tool_options
         end
 
@@ -18,7 +18,11 @@ module QuietQuality
 
         private
 
-        attr_reader :text
+        attr_reader :outcome, :tool_options
+
+        def text
+          outcome.output
+        end
 
         def content
           @_content ||= JSON.parse(text, symbolize_names: true)

--- a/lib/quiet_quality/tools/markdown_lint/parser.rb
+++ b/lib/quiet_quality/tools/markdown_lint/parser.rb
@@ -2,8 +2,9 @@ module QuietQuality
   module Tools
     module MarkdownLint
       class Parser
-        def initialize(text)
+        def initialize(text, tool_options:)
           @text = text
+          @tool_options = tool_options
         end
 
         def messages

--- a/lib/quiet_quality/tools/markdown_lint/parser.rb
+++ b/lib/quiet_quality/tools/markdown_lint/parser.rb
@@ -2,8 +2,8 @@ module QuietQuality
   module Tools
     module MarkdownLint
       class Parser
-        def initialize(text, tool_options:)
-          @text = text
+        def initialize(outcome, tool_options:)
+          @outcome = outcome
           @tool_options = tool_options
         end
 
@@ -15,7 +15,11 @@ module QuietQuality
 
         private
 
-        attr_reader :text
+        attr_reader :outcome, :tool_options
+
+        def text
+          outcome.output
+        end
 
         def content
           @_content ||= JSON.parse(text, symbolize_names: true)

--- a/lib/quiet_quality/tools/outcome.rb
+++ b/lib/quiet_quality/tools/outcome.rb
@@ -1,13 +1,14 @@
 module QuietQuality
   module Tools
     class Outcome
-      attr_reader :output, :logging, :tool
+      attr_reader :output, :logging, :tool, :exit_status
 
-      def initialize(tool:, output:, logging: nil, failure: false)
+      def initialize(tool:, output:, logging: nil, failure: false, exit_status: nil)
         @tool = tool
         @output = output
         @logging = logging
         @failure = failure
+        @exit_status = exit_status
       end
 
       def failure?

--- a/lib/quiet_quality/tools/rspec/parser.rb
+++ b/lib/quiet_quality/tools/rspec/parser.rb
@@ -4,8 +4,8 @@ module QuietQuality
       class Parser
         include Logging
 
-        def initialize(text, tool_options:)
-          @text = text
+        def initialize(outcome, tool_options:)
+          @outcome = outcome
           @tool_options = tool_options
         end
 
@@ -17,7 +17,11 @@ module QuietQuality
 
         private
 
-        attr_reader :text, :tool_options
+        attr_reader :outcome, :tool_options
+
+        def text
+          outcome.output
+        end
 
         # Many people use simplecov with rspec, and its default formatter
         # writes text output into the stdout stream of rspec even when rspec is

--- a/lib/quiet_quality/tools/rspec/parser.rb
+++ b/lib/quiet_quality/tools/rspec/parser.rb
@@ -4,8 +4,9 @@ module QuietQuality
       class Parser
         include Logging
 
-        def initialize(text)
+        def initialize(text, tool_options:)
           @text = text
+          @tool_options = tool_options
         end
 
         def messages
@@ -16,7 +17,7 @@ module QuietQuality
 
         private
 
-        attr_reader :text
+        attr_reader :text, :tool_options
 
         # Many people use simplecov with rspec, and its default formatter
         # writes text output into the stdout stream of rspec even when rspec is

--- a/lib/quiet_quality/tools/rspec/runner.rb
+++ b/lib/quiet_quality/tools/rspec/runner.rb
@@ -21,6 +21,18 @@ module QuietQuality
         def relevant_path?(path)
           path.end_with?("_spec.rb")
         end
+
+        # When simplecov is set up, it exits with a 2 when there's a _coverage_ failure
+        # (and no test failures).
+        def success_status?(stat)
+          return !!changed_files if [2, 3].include?(stat.exitstatus)
+          super
+        end
+
+        def failure_status?(stat)
+          return !changed_files if [2, 3].include?(stat.exitstatus)
+          super
+        end
       end
     end
   end

--- a/lib/quiet_quality/tools/rubocop/parser.rb
+++ b/lib/quiet_quality/tools/rubocop/parser.rb
@@ -2,8 +2,8 @@ module QuietQuality
   module Tools
     module Rubocop
       class Parser
-        def initialize(text, tool_options:)
-          @text = text
+        def initialize(outcome, tool_options:)
+          @outcome = outcome
           @tool_options = tool_options
         end
 
@@ -18,7 +18,11 @@ module QuietQuality
 
         private
 
-        attr_reader :text, :tool_options
+        attr_reader :outcome, :tool_options
+
+        def text
+          outcome.output
+        end
 
         def content
           @_content ||= JSON.parse(text, symbolize_names: true)

--- a/lib/quiet_quality/tools/rubocop/parser.rb
+++ b/lib/quiet_quality/tools/rubocop/parser.rb
@@ -2,8 +2,9 @@ module QuietQuality
   module Tools
     module Rubocop
       class Parser
-        def initialize(text)
+        def initialize(text, tool_options:)
           @text = text
+          @tool_options = tool_options
         end
 
         def messages
@@ -17,7 +18,7 @@ module QuietQuality
 
         private
 
-        attr_reader :text
+        attr_reader :text, :tool_options
 
         def content
           @_content ||= JSON.parse(text, symbolize_names: true)

--- a/spec/quiet_quality/executors/pipeline_spec.rb
+++ b/spec/quiet_quality/executors/pipeline_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe QuietQuality::Executors::Pipeline do
     it "passes the expected data to the parser" do
       messages
       expect(QuietQuality::Tools::Rspec::Parser).to have_received(:new)
-        .with(runner_outcome.output, tool_options: tool_opts)
+        .with(runner_outcome, tool_options: tool_opts)
     end
   end
 end

--- a/spec/quiet_quality/executors/pipeline_spec.rb
+++ b/spec/quiet_quality/executors/pipeline_spec.rb
@@ -180,5 +180,11 @@ RSpec.describe QuietQuality::Executors::Pipeline do
         expect_info("Messages for rspec positioned into the diff for annotation purposes")
       end
     end
+
+    it "passes the expected data to the parser" do
+      messages
+      expect(QuietQuality::Tools::Rspec::Parser).to have_received(:new)
+        .with(runner_outcome.output, tool_options: tool_opts)
+    end
   end
 end

--- a/spec/quiet_quality/tools/brakeman/parser_spec.rb
+++ b/spec/quiet_quality/tools/brakeman/parser_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe QuietQuality::Tools::Brakeman::Parser do
-  subject(:parser) { described_class.new(text) }
+  subject(:parser) { described_class.new(text, tool_options: {}) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "brakeman", "no-failures.json") }

--- a/spec/quiet_quality/tools/brakeman/parser_spec.rb
+++ b/spec/quiet_quality/tools/brakeman/parser_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe QuietQuality::Tools::Brakeman::Parser do
-  subject(:parser) { described_class.new(text, tool_options: {}) }
+  let(:outcome) { build_outcome(tool: :brakeman, output: text, logging: "") }
+  subject(:parser) { described_class.new(outcome, tool_options: {}) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "brakeman", "no-failures.json") }

--- a/spec/quiet_quality/tools/haml_lint/parser_spec.rb
+++ b/spec/quiet_quality/tools/haml_lint/parser_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe QuietQuality::Tools::HamlLint::Parser do
-  subject(:parser) { described_class.new(text) }
+  subject(:parser) { described_class.new(text, tool_options: {}) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "haml_lint", "no-failures.json") }

--- a/spec/quiet_quality/tools/haml_lint/parser_spec.rb
+++ b/spec/quiet_quality/tools/haml_lint/parser_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe QuietQuality::Tools::HamlLint::Parser do
-  subject(:parser) { described_class.new(text, tool_options: {}) }
+  let(:outcome) { build_outcome(tool: :haml_lint, output: text, logging: "") }
+  subject(:parser) { described_class.new(outcome, tool_options: {}) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "haml_lint", "no-failures.json") }

--- a/spec/quiet_quality/tools/markdown_lint/parser_spec.rb
+++ b/spec/quiet_quality/tools/markdown_lint/parser_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe QuietQuality::Tools::MarkdownLint::Parser do
-  subject(:parser) { described_class.new(text) }
+  subject(:parser) { described_class.new(text, tool_options: {}) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "markdown_lint", "no-failures.json") }

--- a/spec/quiet_quality/tools/markdown_lint/parser_spec.rb
+++ b/spec/quiet_quality/tools/markdown_lint/parser_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe QuietQuality::Tools::MarkdownLint::Parser do
-  subject(:parser) { described_class.new(text, tool_options: {}) }
+  let(:outcome) { build_outcome(tool: :markdown_lint, output: text, logging: "") }
+  subject(:parser) { described_class.new(outcome, tool_options: {}) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "markdown_lint", "no-failures.json") }

--- a/spec/quiet_quality/tools/outcome_spec.rb
+++ b/spec/quiet_quality/tools/outcome_spec.rb
@@ -3,7 +3,9 @@ RSpec.describe QuietQuality::Tools::Outcome do
   let(:failure) { false }
   let(:output) { "fake output" }
   let(:logging) { "fake logging" }
-  subject(:outcome) { described_class.new(tool: tool, output: output, logging: logging, failure: failure) }
+  let(:exit_status) { 0 }
+  let(:params) { {tool: tool, output: output, logging: logging, failure: failure, exit_status: exit_status} }
+  subject(:outcome) { described_class.new(**params) }
 
   describe "#failure?" do
     subject(:failure?) { outcome.failure? }
@@ -34,13 +36,15 @@ RSpec.describe QuietQuality::Tools::Outcome do
   end
 
   describe "#==" do
-    let(:other) { build_outcome(tool: other_tool, output: other_output, logging: other_logging, failure: other_failure) }
+    let(:other_params) { {tool: other_tool, output: other_output, logging: other_logging, failure: other_failure, exit_status: other_exit_status} }
+    let(:other) { build_outcome(**other_params) }
     subject(:equality) { outcome == other }
 
     let(:other_tool) { tool }
     let(:other_output) { output }
     let(:other_logging) { logging }
     let(:other_failure) { failure }
+    let(:other_exit_status) { exit_status }
 
     context "when all match" do
       it { is_expected.to be_truthy }

--- a/spec/quiet_quality/tools/rspec/parser_spec.rb
+++ b/spec/quiet_quality/tools/rspec/parser_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe QuietQuality::Tools::Rspec::Parser do
-  subject(:parser) { described_class.new(text) }
+  subject(:parser) { described_class.new(text, tool_options: {}) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "rspec", "no-failures.json") }

--- a/spec/quiet_quality/tools/rspec/parser_spec.rb
+++ b/spec/quiet_quality/tools/rspec/parser_spec.rb
@@ -1,9 +1,11 @@
 RSpec.describe QuietQuality::Tools::Rspec::Parser do
-  let(:outcome) { build_outcome(tool: :rspec, output: text, logging: "") }
-  subject(:parser) { described_class.new(outcome, tool_options: {}) }
+  let(:outcome) { build_outcome(tool: :rspec, output: text, logging: "", exit_status: exit_status) }
+  let(:topts) { tool_options(:rspec) }
+  subject(:parser) { described_class.new(outcome, tool_options: topts) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "rspec", "no-failures.json") }
+    let(:exit_status) { 0 }
     subject(:messages) { parser.messages }
 
     it "is memoized" do
@@ -15,9 +17,16 @@ RSpec.describe QuietQuality::Tools::Rspec::Parser do
       let(:text) { fixture_content("tools", "rspec", "no-failures.json") }
       it { is_expected.to be_a(QuietQuality::Messages) }
       it { is_expected.to be_empty }
+
+      context "with limit_targets = true" do
+        let(:topts) { tool_options(:rspec, limit_targets: false) }
+        it { is_expected.to be_a(QuietQuality::Messages) }
+        it { is_expected.to be_empty }
+      end
     end
 
     context "when there are some offenses" do
+      let(:exit_status) { 1 }
       let(:text) { fixture_content("tools", "rspec", "failures.json") }
       it { is_expected.to be_a(QuietQuality::Messages) }
       it { is_expected.not_to be_empty }
@@ -68,6 +77,7 @@ RSpec.describe QuietQuality::Tools::Rspec::Parser do
     end
 
     context "when there are errors outside of examples" do
+      let(:exit_status) { 1 }
       let(:text) { fixture_content("tools", "rspec", "errors-outside-of-examples.json") }
 
       it "raises an Rspec::Error" do
@@ -78,6 +88,54 @@ RSpec.describe QuietQuality::Tools::Rspec::Parser do
         expect_warn "RSpec errors:"
         expect_warn a_string_matching(/An error occurred while loading/)
         expect_warn "No examples found."
+      end
+    end
+
+    context "when rspec exits with 2 (simplecov insufficient-coverage)" do
+      let(:exit_status) { 2 }
+
+      context "with limit_targets = true" do
+        let(:topts) { tool_options(:rspec, limit_targets: true) }
+        it { is_expected.to be_a(QuietQuality::Messages) }
+        it { is_expected.to be_empty }
+      end
+
+      context "with limit_targets = false" do
+        let(:topts) { tool_options(:rspec, limit_targets: false) }
+        it { is_expected.to be_a(QuietQuality::Messages) }
+        it { is_expected.not_to be_empty }
+
+        it "has the expected offense in it" do
+          expect(messages.count).to eq(1)
+          expect(messages.first.body).to eq("Net coverage was insufficient")
+          expect(messages.first.rule).to eq("Net Coverage")
+          expect(messages.first.tool_name).to eq(:rspec)
+          expect(messages.first.path).to eq("all")
+        end
+      end
+    end
+
+    context "when rspec exits with 3 (simplecov per-file insufficient-coverage)" do
+      let(:exit_status) { 3 }
+
+      context "with limit_targets = true" do
+        let(:topts) { tool_options(:rspec, limit_targets: true) }
+        it { is_expected.to be_a(QuietQuality::Messages) }
+        it { is_expected.to be_empty }
+      end
+
+      context "with limit_targets = false" do
+        let(:topts) { tool_options(:rspec, limit_targets: false) }
+        it { is_expected.to be_a(QuietQuality::Messages) }
+        it { is_expected.not_to be_empty }
+
+        it "has the expected offense in it" do
+          expect(messages.count).to eq(1)
+          expect(messages.first.body).to eq("Per-file coverage was insufficient")
+          expect(messages.first.rule).to eq("Per-File Coverage")
+          expect(messages.first.tool_name).to eq(:rspec)
+          expect(messages.first.path).to eq("all")
+        end
       end
     end
   end

--- a/spec/quiet_quality/tools/rspec/parser_spec.rb
+++ b/spec/quiet_quality/tools/rspec/parser_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe QuietQuality::Tools::Rspec::Parser do
-  subject(:parser) { described_class.new(text, tool_options: {}) }
+  let(:outcome) { build_outcome(tool: :rspec, output: text, logging: "") }
+  subject(:parser) { described_class.new(outcome, tool_options: {}) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "rspec", "no-failures.json") }

--- a/spec/quiet_quality/tools/rspec/runner_spec.rb
+++ b/spec/quiet_quality/tools/rspec/runner_spec.rb
@@ -61,4 +61,55 @@ RSpec.describe QuietQuality::Tools::Rspec::Runner do
       it { is_expected.to be_falsey }
     end
   end
+
+  def self.it_considers(status:, to_be:)
+    context "when the process exits with #{status}" do
+      let(:stat) { mock_status(status) }
+      it { is_expected.to eq(to_be) }
+    end
+  end
+
+  describe "#success_status?" do
+    subject(:success_status?) { runner.success_status?(stat) }
+
+    context "when running with 'changed_files'" do
+      let(:changed_files) { fully_changed_files("/tmp/foo") }
+      it_considers(status: 0, to_be: true)
+      it_considers(status: 1, to_be: false)
+      it_considers(status: 2, to_be: true)
+      it_considers(status: 3, to_be: true)
+      it_considers(status: 99, to_be: false)
+    end
+
+    context "when running without 'changed_files'" do
+      let(:changed_files) { nil }
+      it_considers(status: 0, to_be: true)
+      it_considers(status: 1, to_be: false)
+      it_considers(status: 2, to_be: false)
+      it_considers(status: 3, to_be: false)
+      it_considers(status: 99, to_be: false)
+    end
+  end
+
+  describe "#failure_status?" do
+    subject(:failure_status) { runner.failure_status?(stat) }
+
+    context "when running with 'changed_files'" do
+      let(:changed_files) { fully_changed_files("/tmp/foo") }
+      it_considers(status: 0, to_be: false)
+      it_considers(status: 1, to_be: true)
+      it_considers(status: 2, to_be: false)
+      it_considers(status: 3, to_be: false)
+      it_considers(status: 99, to_be: false)
+    end
+
+    context "when running without 'changed_files'" do
+      let(:changed_files) { nil }
+      it_considers(status: 0, to_be: false)
+      it_considers(status: 1, to_be: true)
+      it_considers(status: 2, to_be: true)
+      it_considers(status: 3, to_be: true)
+      it_considers(status: 99, to_be: false)
+    end
+  end
 end

--- a/spec/quiet_quality/tools/rubocop/parser_spec.rb
+++ b/spec/quiet_quality/tools/rubocop/parser_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe QuietQuality::Tools::Rubocop::Parser do
-  subject(:parser) { described_class.new(text) }
+  subject(:parser) { described_class.new(text, tool_options: {}) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "rubocop", "no-failures.json") }

--- a/spec/quiet_quality/tools/rubocop/parser_spec.rb
+++ b/spec/quiet_quality/tools/rubocop/parser_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe QuietQuality::Tools::Rubocop::Parser do
-  subject(:parser) { described_class.new(text, tool_options: {}) }
+  let(:outcome) { build_outcome(tool: :rubocop, output: text, logging: "") }
+  subject(:parser) { described_class.new(outcome, tool_options: {}) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "rubocop", "no-failures.json") }

--- a/spec/quiet_quality/tools/standardrb/parser_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/parser_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe QuietQuality::Tools::Standardrb::Parser do
-  subject(:parser) { described_class.new(text, tool_options: {}) }
+  let(:outcome) { build_outcome(tool: :standardrb, output: text, logging: "") }
+  subject(:parser) { described_class.new(outcome, tool_options: {}) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "standardrb", "no-failures.json") }

--- a/spec/quiet_quality/tools/standardrb/parser_spec.rb
+++ b/spec/quiet_quality/tools/standardrb/parser_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe QuietQuality::Tools::Standardrb::Parser do
-  subject(:parser) { described_class.new(text) }
+  subject(:parser) { described_class.new(text, tool_options: {}) }
 
   describe "#messages" do
     let(:text) { fixture_content("tools", "standardrb", "no-failures.json") }

--- a/spec/support/outcome_setup.rb
+++ b/spec/support/outcome_setup.rb
@@ -1,10 +1,11 @@
 module OutcomeSetup
-  def build_outcome(tool:, output: nil, logging: nil, failure: false)
+  def build_outcome(tool:, output: nil, logging: nil, failure: false, exit_status: nil)
     QuietQuality::Tools::Outcome.new(
       tool: tool,
       output: output || "none",
       logging: logging,
-      failure: failure
+      failure: failure,
+      exit_status: exit_status
     )
   end
 


### PR DESCRIPTION
When you run rspec _with simplecov_, it exposes some interesting failure modes. Aside from the "--format=json" disobedience (#133), we have a new failure mode: when the tests pass, but simplecov fails because coverage wasn't sufficient.

This is .. complicated by the fact that simplecov still runs (if you tell it to) when you are only running _portions_ of the test suite. With `quiet_quality`, that's pretty much `tool_options.limit_targets?`.

* pass the `tool_options` into each parser (though only rspec's uses it)
* pass the `outcome` into each parser, instead of the output text itself
* update the rspec _runner_ to consider exit statuses 2 and 3 "failures" when we're not limiting targets, and successes when we are
* update the rspec _parser_ to expose an appropriate _invented_ Message when exit-status 2 or 3 is encountered and we are limiting targets.
